### PR TITLE
Add Atom editor grammars

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "editors/Atom"]
+	path = editors/Atom
+	url = https://github.com/acaprojects/language-m
+	branch = master


### PR DESCRIPTION
I've added these as a submodule as this appears to be the simplest means of providing a download that people can add to their editor instance (if not wanting to grab it via [Atom's internal package manager](https://atom.io/packages/language-m)). Feel free to reject this is you prefer to keep this repo submodule free and I'll resubmit the PR with the *.cson files directly.