### PR TITLE
Gateway: availability of DirectQuery with Enterprise mode

### DIFF
--- a/docs/m-extensions.md
+++ b/docs/m-extensions.md
@@ -360,7 +360,7 @@ shared GithubSample.Contents = Value.ReplaceType(Github.Contents, type function 
 ### Implementing TestConnection for Gateway Support
 
 > Custom Connector support is now available in both Personal and Enterprise modes of the [On-Premises Data Gateway](https://powerbi.microsoft.com/en-us/blog/on-premises-data-gateway-july-update-is-now-available/).
-> Both gateway modes support **Import** - **Direct Query** support in the Enterprise mode is targeted at an upcoming release.
+> Both gateway modes support **Import** and **Direct Query**.
 
 > The method for implementing TestConnection functionality is likely to change prior while the Power BI Custom Data Connector functionality is in preview.
 


### PR DESCRIPTION
According to the release notes of the On-premises gateway, the DirectQuery mode is now supported for both personal and enterprise modes. See at https://powerbi.microsoft.com/en-us/blog/on-premises-data-gateway-august-update-is-now-available/