### PR TITLE
Update paging function Table.FromList parameters in helper-functions.md

### DIFF
--- a/docs/helper-functions.md
+++ b/docs/helper-functions.md
@@ -129,7 +129,9 @@ Table.GenerateByPage = (getNextPage as function) as table =>
             (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
         ),
         // concatenate the pages together
-        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        // the two optional parameters will allow paged responses that might have inconsistent
+        // schemas to be converted to a table that can be processed further in the calling function(s)
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}, null, ExtraValues.Ignore),
         firstRow = tableOfPages{0}?
     in
         // if we didn't get back any pages of data, return an empty table


### PR DESCRIPTION
An API response is not guaranteed to have the same number of properties on every page of a response. In many .Net projects response serialization has options enabled to remove properties with NULL values. When a mismatch occurs, this Table.FromList as documented will error out, preventing the subsequent functions from taking the results and adding them to the schema. On a number of PoC projects I have used Data Connectors with this continually bit me until I dug in and realized that this function call was incomplete with disparate responses