### PR TITLE
Update TripPin.pq

### DIFF
--- a/samples/TripPin/6-Schema/TripPin.pq
+++ b/samples/TripPin/6-Schema/TripPin.pq
@@ -96,7 +96,7 @@ GetPage = (url as text, optional schema as table) as table =>
         response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
         body = Json.Document(response),
         nextLink = GetNextLink(body),
-        data = Table.FromRecords(body[value]),
+        data = Table.FromRecords(body[value], schema[Name], MissingField.UseNull),
         // enforce the schema
         withSchema = if (schema <> null) then SchemaTransformTable(data, schema) else data
     in


### PR DESCRIPTION
By default, the `Table.FromRecords` function utilizes the column names from the first record for the remaining records. If that record is missing columns, the rest of the records will be NULL.  More problematic, however, is when responses from multiple pages of an API request have different sets of fields.  In this case, the paged function doesn't know how to stitch the individual pages back together because they have different column counts.  This is not uncommon from APIs that remove NULL values from the response.

Passing the schema columns names into this `Table.FromRecords` function does prevent the overall flow from being "dynamic", but it prevents errors when responses within a paged route are different. The `SchemaTransformTable` function can still be used, it's main value being to set column types.