### PR TITLE
Update Table.GenerateByPage to handle empty tables being returned

### DIFF
--- a/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -1,16 +1,23 @@
-(getNextPage as function) as table =>
-    let        
+(
+    getNextPage as function,
+    optional tableType as type
+) as table =>
+    let
         listOfPages = List.Generate(
             () => getNextPage(null),            // get the first page of data
             (lastPage) => lastPage <> null,     // stop when the function returns null
             (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
         ),
-        firstRow = listOfPages{0}?
+        filteredListOfPages = List.Select(listOfPages, each not Table.IsEmpty(_)),
+        tableOfPages = Table.FromList(filteredListOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?,
+        appliedType = if tableType = null then Value.Type(firstRow[Column1]) else tableType,
+        columns = Record.FieldNames(Type.RecordFields(Type.TableRow(appliedType)))
     in
-        if (firstRow = null) then
+        if tableType = null and firstRow = null then
             Table.FromRows({})
-        else        
+        else
             Value.ReplaceType(
-                Table.Combine(listOfPages, Table.ColumnNames(firstRow)),
-                Value.Type(firstRow)
+                Table.ExpandTableColumn(tableOfPages, "Column1", columns),
+                appliedType
             )

--- a/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -1,23 +1,16 @@
-﻿(getNextPage as function) as table =>
+(getNextPage as function) as table =>
     let        
         listOfPages = List.Generate(
             () => getNextPage(null),            // get the first page of data
             (lastPage) => lastPage <> null,     // stop when the function returns null
             (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
         ),
-        // concatenate the pages together
-        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = listOfPages{0}?
     in
-        // if we didn't get back any pages of data, return an empty table
-        // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-		// check for empty first table
-		else if (Table.IsEmpty(firstRow[Column1])) then
-			firstRow[Column1]
-        else
+        else        
             Value.ReplaceType(
-                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
-                Value.Type(firstRow[Column1])
+                Table.Combine(listOfPages, Table.ColumnNames(firstRow)),
+                Value.Type(firstRow)
             )

--- a/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -2,22 +2,22 @@
     getNextPage as function,
     optional tableType as type
 ) as table =>
-    let
+let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
-        ),
-        filteredListOfPages = List.Select(listOfPages, each not Table.IsEmpty(_)),
-        tableOfPages = Table.FromList(filteredListOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?,
-        appliedType = if tableType = null then Value.Type(firstRow[Column1]) else tableType,
-        columns = Record.FieldNames(Type.RecordFields(Type.TableRow(appliedType)))
-    in
-        if tableType = null and firstRow = null then
-            Table.FromRows({})
-        else
-            Value.ReplaceType(
-                Table.ExpandTableColumn(tableOfPages, "Column1", columns),
-                appliedType
-            )
+        () => getNextPage(null),
+        (lastPage) => lastPage <> null,
+        (lastPage) => getNextPage(lastPage)
+    ),
+    filteredListOfPages = List.Select(listOfPages, each not Table.IsEmpty(_)),
+    tableOfPages = Table.FromList(filteredListOfPages, Splitter.SplitByNothing(), {"Column1"}),
+    firstRow = tableOfPages{0}?,
+    appliedType = 
+        if tableType <> null then tableType
+        else if firstRow <> null then Value.Type(firstRow[Column1]) 
+        else type table[],
+    columns = Record.FieldNames(Type.RecordFields(Type.TableRow(appliedType)))
+in
+    Value.ReplaceType(
+        Table.ExpandTableColumn(tableOfPages, "Column1", columns),
+        appliedType
+    )

--- a/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -12,7 +12,7 @@ let
     tableOfPages = Table.FromList(filteredListOfPages, Splitter.SplitByNothing(), {"Column1"}),
     firstRow = tableOfPages{0}?,
     appliedType = 
-        if tableType <> null and not (try firstRow)[HasError] then tableType
+        if tableType <> null then tableType
         else if firstRow <> null then Value.Type(firstRow[Column1]) 
         else type table[],
     columns = Record.FieldNames(Type.RecordFields(Type.TableRow(appliedType)))

--- a/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -12,7 +12,7 @@ let
     tableOfPages = Table.FromList(filteredListOfPages, Splitter.SplitByNothing(), {"Column1"}),
     firstRow = tableOfPages{0}?,
     appliedType = 
-        if tableType <> null then tableType
+        if tableType <> null and not (try firstRow)[HasError] then tableType
         else if firstRow <> null then Value.Type(firstRow[Column1]) 
         else type table[],
     columns = Record.FieldNames(Type.RecordFields(Type.TableRow(appliedType)))


### PR DESCRIPTION
Per `Table.GenerateByPage`'s [Helper Functions](https://docs.microsoft.com/en-us/power-query/helperfunctions#tablegeneratebypage) description, this method should call `getNextPage` until that callback returns null, then will combine all returned pages into a single table.

However, when the existing `Table.GenerateByPage` returns an empty table, its actual behavior differs from the above description (see below examples). If the callback returns an empty table, `Table.GenerateByPage` may output 0 rows or an extra, all-null row--neither of which seems desirable or in alignment with the above description.

This PR addresses these behavior anomalies. (Note: It would be good for someone with internal Power Query knowledge to validate this PR to ensure that it is done in a way that aligns with PQ's lazy paradigm and that it does not trigger extra streaming.)

## Demo of Existing's Behavior Anomalies
````
let
    // Existing version of this method
    Table.GenerateByPage = 
        (getNextPage as function) as table =>
            let        
                listOfPages = List.Generate(
                    () => getNextPage(null),            // get the first page of data
                    (lastPage) => lastPage <> null,     // stop when the function returns null
                    (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
                ),
                // concatenate the pages together
                tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
                firstRow = tableOfPages{0}?
            in
                // if we didn't get back any pages of data, return an empty table
                // otherwise set the table type based on the columns of the first page
                if (firstRow = null) then
                    Table.FromRows({})
                // check for empty first table
                else if (Table.IsEmpty(firstRow[Column1])) then
                    firstRow[Column1]
                else
                    Value.ReplaceType(
                        Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
                        Value.Type(firstRow[Column1])
                    )
    ,
    PageFunction = (previous) => 
        let
            /*
            // Actual: In this scenario, 2 rows are output, the 2nd holding a null column value because Response2 contained 0 rows.
            // Expected: Only 1 row (from Response1) should have been returned.
            Response1 = #table({"A"},{{1}}),
            Response2 = #table({"A"},{})
            */
            // Actual: In this scenario, 0 rows are output. Response1 contained no rows so Response2's data is skipped
            // Expected: 1 row returned (row from Response2)
            Response1 = #table({"A"},{}),
            Response2 = #table({"A"},{{1}})
        in
            if previous = null then Response1 
            else if previous = Response1 then Response2
            else null,
    Result = Table.GenerateByPage(PageFunction)
in
    Result
````