### PR TITLE
Format *.pq[m] files, part (1)

### DIFF
--- a/samples/HelloWorldWithDocs/HelloWorldWithDocs.pq
+++ b/samples/HelloWorldWithDocs/HelloWorldWithDocs.pq
@@ -40,8 +40,9 @@ HelloWorldImpl = (message as text, optional count as number) as table =>
 HelloWorldWithDocs = [
     Authentication = [
         Anonymous = []
-    ]//,
-    //Label = "Hello World With Docs"
+    ]
+    // ,
+    // Label = "Hello World With Docs"
 ];
 
 // Data Source UI publishing description

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/Diagnostics.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/OdbcConstants.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/OdbcConstants.pqm
@@ -66,7 +66,7 @@
 
 SQL_CVT =
 [
-    //None = 0,
+    // None = 0,
 
     CHAR = 0x00000001,
     NUMERIC = 0x00000002,
@@ -116,15 +116,17 @@ SQL_CVT =
         SMALLINT = -8
     ],
 
-    //SQL Server specific defines
+    // SQL Server specific defines
     //
-    SQL_HC =                        // from Odbcss.h
+         // from Odbcss.h
+         SQL_HC =                   
     [
         OFF = 0,                //  FOR BROWSE columns are hidden
         ON = 1                //  FOR BROWSE columns are exposed
     ],
 
-    SQL_NB =                         // from Odbcss.h
+         // from Odbcss.h
+         SQL_NB =                    
     [
         OFF = 0,                //  NO_BROWSETABLE is off
         ON = 1                //  NO_BROWSETABLE is on
@@ -134,7 +136,8 @@ SQL_CVT =
     //  SQLSet/GetDescField driver specific defines.
     //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
-    SQL_CA_SS =                      // from Odbcss.h
+         // from Odbcss.h
+         SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
@@ -146,18 +149,19 @@ SQL_CVT =
 
     ],
 
-    SQL_SOPT_SS =                    // from Odbcss.h
+         // from Odbcss.h
+         SQL_SOPT_SS =               
     [
         BASE = 1225,                // SQL_SOPT_SS_BASE
         HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
         NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
     ],
 
-    SQL_COMMIT = 0,      //Commit
-    SQL_ROLLBACK = 1,      //Abort
+    SQL_COMMIT = 0,      // Commit
+    SQL_ROLLBACK = 1,      // Abort
 
-    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
-    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+    // static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    // static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
 
     SQL_TRANSACTION =
     [
@@ -276,7 +280,7 @@ SQL_CVT =
         NESTED = 0x00000008,    // SQL_OJ_NESTED
         NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
         INNER = 0x00000020,    // SQL_OJ_INNER
-        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+        ALL_COMPARISON_OPS = 0x00000040  // SQL_OJ_ALLCOMPARISION+OPS
     ],
 
     SQL_UPDATABLE =
@@ -454,8 +458,8 @@ SQL_CVT =
         SS_TIMESTAMPOFFSET  = -155
     ],
 
-    //SQL_ALL_TYPES = 0,
-    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+    // SQL_ALL_TYPES = 0,
+    // static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
 
     SQL_LENGTH = 
     [
@@ -521,7 +525,7 @@ SQL_CVT =
 
     SQL_GD = 
     [
-        //None =  0,
+        // None =  0,
         ANY_COLUMN = 1,
         ANY_ORDER = 2,
         BLOCK = 4,
@@ -529,7 +533,7 @@ SQL_CVT =
         OUTPUT_PARAMS = 16
     ],
 
-    //SQLGetInfo
+    // SQLGetInfo
 /*
     SQL_INFO =
     [
@@ -773,7 +777,7 @@ SQL_CVT =
 
     SQL_SP = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SP_EXISTS = 0x00000001,
         SQL_SP_ISNOTNULL = 0x00000002,
@@ -902,7 +906,7 @@ SQL_CVT =
 
     SQL_FN_CVT = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_CVT_CONVERT        = 0x00000001,
         SQL_FN_CVT_CAST        = 0x00000002
@@ -910,7 +914,7 @@ SQL_CVT =
 
     SQL_FN_NUM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_NUM_ABS        = 0x00000001,
         SQL_FN_NUM_ACOS        = 0x00000002,
@@ -950,7 +954,7 @@ SQL_CVT =
 
     SQL_FN_STR =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_STR_CONCAT            = 0x00000001,
         SQL_FN_STR_INSERT            = 0x00000002,
@@ -980,7 +984,7 @@ SQL_CVT =
 
     SQL_FN_SYSTEM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_SYS_USERNAME = 0x00000001,
         SQL_FN_SYS_DBNAME = 0x00000002,
@@ -989,7 +993,7 @@ SQL_CVT =
 
     SQL_FN_TD = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_TD_NOW            = 0x00000001,
         SQL_FN_TD_CURDATE            = 0x00000002,
@@ -1023,7 +1027,7 @@ SQL_CVT =
 
     SQL_TSI =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_TSI_FRAC_SECOND = 0x00000001,
         SQL_TSI_SECOND = 0x00000002,
@@ -1038,7 +1042,7 @@ SQL_CVT =
 
     SQL_AF = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_AF_AVG        = 0x00000001,
         SQL_AF_COUNT    = 0x00000002,
@@ -1053,7 +1057,7 @@ SQL_CVT =
 
     SQL_SC = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SC_SQL92_ENTRY            = 0x00000001,
         SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
@@ -1086,7 +1090,7 @@ SQL_CVT =
         SQL_IK_NONE        = 0x00000000,
         SQL_IK_ASC        = 0x00000001,
         SQL_IK_DESC        = 0x00000002,
-        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+        SQL_IK_ALL = 0x00000003 // SQL_IK_ASC | SQL_IK_DESC
     ],
 
     SQL_ISV = 
@@ -1118,7 +1122,7 @@ SQL_CVT =
 
     SQL_SRJO = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
         SQL_SRJO_CROSS_JOIN = 0x00000002,
@@ -1140,10 +1144,11 @@ SQL_CVT =
         SQL_SRVC_ROW_SUBQUERY = 0x00000008
     ],
 
-    //public static readonly int SQL_OV_ODBC3 = 3;
-    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+    // public static readonly int SQL_OV_ODBC3 = 3;
+    // public const Int32 SQL_NTS = -3;
+    // flags for null-terminated string
 
-    //Pooling
+    // Pooling
     SQL_CP = 
     [
         OFF = 0,

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/OdbcConstants.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/OdbcConstants.pqm
@@ -129,7 +129,7 @@ SQL_CVT =
          SQL_NB =                    
     [
         OFF = 0,                // NO_BROWSETABLE is off
-        ON = 1                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is on
     ],
 
     // SQLColAttributes driver specific defines.

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/OdbcConstants.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/OdbcConstants.pqm
@@ -121,28 +121,28 @@ SQL_CVT =
          // from Odbcss.h
          SQL_HC =                   
     [
-        OFF = 0,                //  FOR BROWSE columns are hidden
-        ON = 1                //  FOR BROWSE columns are exposed
+        OFF = 0,                // FOR BROWSE columns are hidden
+        ON = 1                // FOR BROWSE columns are exposed
     ],
 
          // from Odbcss.h
          SQL_NB =                    
     [
-        OFF = 0,                //  NO_BROWSETABLE is off
-        ON = 1                //  NO_BROWSETABLE is on
+        OFF = 0,                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is off
     ],
 
-    //  SQLColAttributes driver specific defines.
-    //  SQLSet/GetDescField driver specific defines.
-    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    // SQLColAttributes driver specific defines.
+    // SQLSet/GetDescField driver specific defines.
+    // Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
          // from Odbcss.h
          SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
-        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
-        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        COLUMN_HIDDEN = 1200 + 11,      // Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      // Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
@@ -30,10 +30,7 @@ Config_DriverName = "SQL Server Native Client 11.0";
 // 
 // SQL_SC = 
 // [
-//     SQL_SC_SQL92_ENTRY            = 1,
-//     SQL_SC_FIPS127_2_TRANSITIONAL = 2,
-//     SQL_SC_SQL92_INTERMEDIATE     = 4,
-//     SQL_SC_SQL92_FULL             = 8
+//      SQL_SC_SQL92_ENTRY            = 1,//       SQL_SC_FIPS127_2_TRANSITIONAL = 2,//  /     SQL_SC_SQL92_INTERMEDIATE     = 4//  //     SQL_SC_SQL92_FULL             = 8
 // ]
 //
 // Set to null to determine the value from the driver.
@@ -204,10 +201,10 @@ shared SqlODBC.Contents = (server as text, optional database as text,optional op
 
         // SQLGetTypeInfo can be specified in two ways:
         // 1. A #table() value that returns the same type information as an ODBC
-        //    call to SQLGetTypeInfo.
+    //   //    call to SQLGetTypeInfo.
         // 2. A function that accepts a table argument, and returns a table. The 
-        //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
-        //    Your function implementation can modify/add to this table.
+   //    //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
+  //     //    Your function implementation can modify/add to this table.
         //
         // For details of the format of the types table parameter and expected return value,
         // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
@@ -30,7 +30,10 @@ Config_DriverName = "SQL Server Native Client 11.0";
 // 
 // SQL_SC = 
 // [
-//      SQL_SC_SQL92_ENTRY            = 1,//       SQL_SC_FIPS127_2_TRANSITIONAL = 2,//  /     SQL_SC_SQL92_INTERMEDIATE     = 4//  //     SQL_SC_SQL92_FULL             = 8
+//      SQL_SC_SQL92_ENTRY            = 1,
+//      SQL_SC_FIPS127_2_TRANSITIONAL = 2,
+//      SQL_SC_SQL92_INTERMEDIATE     = 4
+//      SQL_SC_SQL92_FULL             = 8
 // ]
 //
 // Set to null to determine the value from the driver.
@@ -201,10 +204,10 @@ shared SqlODBC.Contents = (server as text, optional database as text,optional op
 
         // SQLGetTypeInfo can be specified in two ways:
         // 1. A #table() value that returns the same type information as an ODBC
-    //   //    call to SQLGetTypeInfo.
+        //  call to SQLGetTypeInfo.
         // 2. A function that accepts a table argument, and returns a table. The 
-   //    //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
-  //     //    Your function implementation can modify/add to this table.
+        //  argument will contain the original results of the ODBC call to SQLGetTypeInfo.
+        // Your function implementation can modify/add to this table.
         //
         // For details of the format of the types table parameter and expected return value,
         // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
@@ -32,7 +32,7 @@ Config_DriverName = "SQL Server Native Client 11.0";
 // [
 //      SQL_SC_SQL92_ENTRY            = 1,
 //      SQL_SC_FIPS127_2_TRANSITIONAL = 2,
-//      SQL_SC_SQL92_INTERMEDIATE     = 4
+//      SQL_SC_SQL92_INTERMEDIATE     = 4,
 //      SQL_SC_SQL92_FULL             = 8
 // ]
 //
@@ -204,10 +204,10 @@ shared SqlODBC.Contents = (server as text, optional database as text,optional op
 
         // SQLGetTypeInfo can be specified in two ways:
         // 1. A #table() value that returns the same type information as an ODBC
-        //  call to SQLGetTypeInfo.
+        //    call to SQLGetTypeInfo.
         // 2. A function that accepts a table argument, and returns a table. The 
-        //  argument will contain the original results of the ODBC call to SQLGetTypeInfo.
-        //  Your function implementation can modify/add to this table.
+        //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
+        //    Your function implementation can modify/add to this table.
         //
         // For details of the format of the types table parameter and expected return value,
         // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function

--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
@@ -207,7 +207,7 @@ shared SqlODBC.Contents = (server as text, optional database as text,optional op
         //  call to SQLGetTypeInfo.
         // 2. A function that accepts a table argument, and returns a table. The 
         //  argument will contain the original results of the ODBC call to SQLGetTypeInfo.
-        // Your function implementation can modify/add to this table.
+        //  Your function implementation can modify/add to this table.
         //
         // For details of the format of the types table parameter and expected return value,
         // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function

--- a/samples/NativeQuery/ODBC/SQL ODBC/Start/Diagnostics.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Start/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/NativeQuery/ODBC/SQL ODBC/Start/OdbcConstants.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Start/OdbcConstants.pqm
@@ -66,7 +66,7 @@
 
 SQL_CVT =
 [
-    //None = 0,
+    // None = 0,
 
     CHAR = 0x00000001,
     NUMERIC = 0x00000002,
@@ -116,15 +116,17 @@ SQL_CVT =
         SMALLINT = -8
     ],
 
-    //SQL Server specific defines
+    // SQL Server specific defines
     //
-    SQL_HC =                        // from Odbcss.h
+         // from Odbcss.h
+         SQL_HC =                   
     [
         OFF = 0,                //  FOR BROWSE columns are hidden
         ON = 1                //  FOR BROWSE columns are exposed
     ],
 
-    SQL_NB =                         // from Odbcss.h
+         // from Odbcss.h
+         SQL_NB =                    
     [
         OFF = 0,                //  NO_BROWSETABLE is off
         ON = 1                //  NO_BROWSETABLE is on
@@ -134,7 +136,8 @@ SQL_CVT =
     //  SQLSet/GetDescField driver specific defines.
     //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
-    SQL_CA_SS =                      // from Odbcss.h
+         // from Odbcss.h
+         SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
@@ -146,18 +149,19 @@ SQL_CVT =
 
     ],
 
-    SQL_SOPT_SS =                    // from Odbcss.h
+         // from Odbcss.h
+         SQL_SOPT_SS =               
     [
         BASE = 1225,                // SQL_SOPT_SS_BASE
         HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
         NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
     ],
 
-    SQL_COMMIT = 0,      //Commit
-    SQL_ROLLBACK = 1,      //Abort
+    SQL_COMMIT = 0,      // Commit
+    SQL_ROLLBACK = 1,      // Abort
 
-    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
-    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+    // static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    // static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
 
     SQL_TRANSACTION =
     [
@@ -276,7 +280,7 @@ SQL_CVT =
         NESTED = 0x00000008,    // SQL_OJ_NESTED
         NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
         INNER = 0x00000020,    // SQL_OJ_INNER
-        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+        ALL_COMPARISON_OPS = 0x00000040  // SQL_OJ_ALLCOMPARISION+OPS
     ],
 
     SQL_UPDATABLE =
@@ -454,8 +458,8 @@ SQL_CVT =
         SS_TIMESTAMPOFFSET  = -155
     ],
 
-    //SQL_ALL_TYPES = 0,
-    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+    // SQL_ALL_TYPES = 0,
+    // static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
 
     SQL_LENGTH = 
     [
@@ -521,7 +525,7 @@ SQL_CVT =
 
     SQL_GD = 
     [
-        //None =  0,
+        // None =  0,
         ANY_COLUMN = 1,
         ANY_ORDER = 2,
         BLOCK = 4,
@@ -529,7 +533,7 @@ SQL_CVT =
         OUTPUT_PARAMS = 16
     ],
 
-    //SQLGetInfo
+    // SQLGetInfo
 /*
     SQL_INFO =
     [
@@ -773,7 +777,7 @@ SQL_CVT =
 
     SQL_SP = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SP_EXISTS = 0x00000001,
         SQL_SP_ISNOTNULL = 0x00000002,
@@ -902,7 +906,7 @@ SQL_CVT =
 
     SQL_FN_CVT = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_CVT_CONVERT        = 0x00000001,
         SQL_FN_CVT_CAST        = 0x00000002
@@ -910,7 +914,7 @@ SQL_CVT =
 
     SQL_FN_NUM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_NUM_ABS        = 0x00000001,
         SQL_FN_NUM_ACOS        = 0x00000002,
@@ -950,7 +954,7 @@ SQL_CVT =
 
     SQL_FN_STR =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_STR_CONCAT            = 0x00000001,
         SQL_FN_STR_INSERT            = 0x00000002,
@@ -980,7 +984,7 @@ SQL_CVT =
 
     SQL_FN_SYSTEM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_SYS_USERNAME = 0x00000001,
         SQL_FN_SYS_DBNAME = 0x00000002,
@@ -989,7 +993,7 @@ SQL_CVT =
 
     SQL_FN_TD = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_TD_NOW            = 0x00000001,
         SQL_FN_TD_CURDATE            = 0x00000002,
@@ -1023,7 +1027,7 @@ SQL_CVT =
 
     SQL_TSI =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_TSI_FRAC_SECOND = 0x00000001,
         SQL_TSI_SECOND = 0x00000002,
@@ -1038,7 +1042,7 @@ SQL_CVT =
 
     SQL_AF = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_AF_AVG        = 0x00000001,
         SQL_AF_COUNT    = 0x00000002,
@@ -1053,7 +1057,7 @@ SQL_CVT =
 
     SQL_SC = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SC_SQL92_ENTRY            = 0x00000001,
         SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
@@ -1086,7 +1090,7 @@ SQL_CVT =
         SQL_IK_NONE        = 0x00000000,
         SQL_IK_ASC        = 0x00000001,
         SQL_IK_DESC        = 0x00000002,
-        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+        SQL_IK_ALL = 0x00000003 // SQL_IK_ASC | SQL_IK_DESC
     ],
 
     SQL_ISV = 
@@ -1118,7 +1122,7 @@ SQL_CVT =
 
     SQL_SRJO = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
         SQL_SRJO_CROSS_JOIN = 0x00000002,
@@ -1140,10 +1144,11 @@ SQL_CVT =
         SQL_SRVC_ROW_SUBQUERY = 0x00000008
     ],
 
-    //public static readonly int SQL_OV_ODBC3 = 3;
-    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+    // public static readonly int SQL_OV_ODBC3 = 3;
+    // public const Int32 SQL_NTS = -3;
+    // flags for null-terminated string
 
-    //Pooling
+    // Pooling
     SQL_CP = 
     [
         OFF = 0,

--- a/samples/NativeQuery/ODBC/SQL ODBC/Start/OdbcConstants.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Start/OdbcConstants.pqm
@@ -129,7 +129,7 @@ SQL_CVT =
          SQL_NB =                    
     [
         OFF = 0,                // NO_BROWSETABLE is off
-        ON = 1                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is on
     ],
 
     // SQLColAttributes driver specific defines.

--- a/samples/NativeQuery/ODBC/SQL ODBC/Start/OdbcConstants.pqm
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Start/OdbcConstants.pqm
@@ -121,28 +121,28 @@ SQL_CVT =
          // from Odbcss.h
          SQL_HC =                   
     [
-        OFF = 0,                //  FOR BROWSE columns are hidden
-        ON = 1                //  FOR BROWSE columns are exposed
+        OFF = 0,                // FOR BROWSE columns are hidden
+        ON = 1                // FOR BROWSE columns are exposed
     ],
 
          // from Odbcss.h
          SQL_NB =                    
     [
-        OFF = 0,                //  NO_BROWSETABLE is off
-        ON = 1                //  NO_BROWSETABLE is on
+        OFF = 0,                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is off
     ],
 
-    //  SQLColAttributes driver specific defines.
-    //  SQLSet/GetDescField driver specific defines.
-    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    // SQLColAttributes driver specific defines.
+    // SQLSet/GetDescField driver specific defines.
+    // Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
          // from Odbcss.h
          SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
-        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
-        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        COLUMN_HIDDEN = 1200 + 11,      // Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      // Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17

--- a/samples/ODBC/HiveSample/Diagnostics.pqm
+++ b/samples/ODBC/HiveSample/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/ODBC/HiveSample/OdbcConstants.pqm
+++ b/samples/ODBC/HiveSample/OdbcConstants.pqm
@@ -66,7 +66,7 @@
 
 SQL_CVT =
 [
-    //None = 0,
+    // None = 0,
 
     CHAR = 0x00000001,
     NUMERIC = 0x00000002,
@@ -116,15 +116,17 @@ SQL_CVT =
         SMALLINT = -8
     ],
 
-    //SQL Server specific defines
+    // SQL Server specific defines
     //
-    SQL_HC =                        // from Odbcss.h
+         // from Odbcss.h
+         SQL_HC =                   
     [
         OFF = 0,                //  FOR BROWSE columns are hidden
         ON = 1                //  FOR BROWSE columns are exposed
     ],
 
-    SQL_NB =                         // from Odbcss.h
+         // from Odbcss.h
+         SQL_NB =                    
     [
         OFF = 0,                //  NO_BROWSETABLE is off
         ON = 1                //  NO_BROWSETABLE is on
@@ -134,7 +136,8 @@ SQL_CVT =
     //  SQLSet/GetDescField driver specific defines.
     //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
-    SQL_CA_SS =                      // from Odbcss.h
+         // from Odbcss.h
+         SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
@@ -146,18 +149,19 @@ SQL_CVT =
 
     ],
 
-    SQL_SOPT_SS =                    // from Odbcss.h
+         // from Odbcss.h
+         SQL_SOPT_SS =               
     [
         BASE = 1225,                // SQL_SOPT_SS_BASE
         HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
         NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
     ],
 
-    SQL_COMMIT = 0,      //Commit
-    SQL_ROLLBACK = 1,      //Abort
+    SQL_COMMIT = 0,      // Commit
+    SQL_ROLLBACK = 1,      // Abort
 
-    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
-    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+    // static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    // static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
 
     SQL_TRANSACTION =
     [
@@ -276,7 +280,7 @@ SQL_CVT =
         NESTED = 0x00000008,    // SQL_OJ_NESTED
         NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
         INNER = 0x00000020,    // SQL_OJ_INNER
-        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+        ALL_COMPARISON_OPS = 0x00000040  // SQL_OJ_ALLCOMPARISION+OPS
     ],
 
     SQL_UPDATABLE =
@@ -454,8 +458,8 @@ SQL_CVT =
         SS_TIMESTAMPOFFSET  = -155
     ],
 
-    //SQL_ALL_TYPES = 0,
-    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+    // SQL_ALL_TYPES = 0,
+    // static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
 
     SQL_LENGTH = 
     [
@@ -521,7 +525,7 @@ SQL_CVT =
 
     SQL_GD = 
     [
-        //None =  0,
+        // None =  0,
         ANY_COLUMN = 1,
         ANY_ORDER = 2,
         BLOCK = 4,
@@ -529,7 +533,7 @@ SQL_CVT =
         OUTPUT_PARAMS = 16
     ],
 
-    //SQLGetInfo
+    // SQLGetInfo
 /*
     SQL_INFO =
     [
@@ -773,7 +777,7 @@ SQL_CVT =
 
     SQL_SP = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SP_EXISTS = 0x00000001,
         SQL_SP_ISNOTNULL = 0x00000002,
@@ -902,7 +906,7 @@ SQL_CVT =
 
     SQL_FN_CVT = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_CVT_CONVERT        = 0x00000001,
         SQL_FN_CVT_CAST        = 0x00000002
@@ -910,7 +914,7 @@ SQL_CVT =
 
     SQL_FN_NUM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_NUM_ABS        = 0x00000001,
         SQL_FN_NUM_ACOS        = 0x00000002,
@@ -955,7 +959,7 @@ SQL_CVT =
 
     SQL_FN_STR =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_STR_CONCAT            = 0x00000001,
         SQL_FN_STR_INSERT            = 0x00000002,
@@ -985,7 +989,7 @@ SQL_CVT =
 
     SQL_FN_SYSTEM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_SYS_USERNAME = 0x00000001,
         SQL_FN_SYS_DBNAME = 0x00000002,
@@ -994,7 +998,7 @@ SQL_CVT =
 
     SQL_FN_TD = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_TD_NOW            = 0x00000001,
         SQL_FN_TD_CURDATE            = 0x00000002,
@@ -1028,7 +1032,7 @@ SQL_CVT =
 
     SQL_TSI =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_TSI_FRAC_SECOND = 0x00000001,
         SQL_TSI_SECOND = 0x00000002,
@@ -1043,7 +1047,7 @@ SQL_CVT =
 
     SQL_AF = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_AF_AVG        = 0x00000001,
         SQL_AF_COUNT    = 0x00000002,
@@ -1058,7 +1062,7 @@ SQL_CVT =
 
     SQL_SC = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SC_SQL92_ENTRY            = 0x00000001,
         SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
@@ -1091,7 +1095,7 @@ SQL_CVT =
         SQL_IK_NONE        = 0x00000000,
         SQL_IK_ASC        = 0x00000001,
         SQL_IK_DESC        = 0x00000002,
-        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+        SQL_IK_ALL = 0x00000003 // SQL_IK_ASC | SQL_IK_DESC
     ],
 
     SQL_ISV = 
@@ -1123,7 +1127,7 @@ SQL_CVT =
 
     SQL_SRJO = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
         SQL_SRJO_CROSS_JOIN = 0x00000002,
@@ -1145,10 +1149,11 @@ SQL_CVT =
         SQL_SRVC_ROW_SUBQUERY = 0x00000008
     ],
 
-    //public static readonly int SQL_OV_ODBC3 = 3;
-    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+    // public static readonly int SQL_OV_ODBC3 = 3;
+    // public const Int32 SQL_NTS = -3;
+    // flags for null-terminated string
 
-    //Pooling
+    // Pooling
     SQL_CP = 
     [
         OFF = 0,

--- a/samples/ODBC/HiveSample/OdbcConstants.pqm
+++ b/samples/ODBC/HiveSample/OdbcConstants.pqm
@@ -129,7 +129,7 @@ SQL_CVT =
          SQL_NB =                    
     [
         OFF = 0,                // NO_BROWSETABLE is off
-        ON = 1                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is on
     ],
 
     // SQLColAttributes driver specific defines.

--- a/samples/ODBC/HiveSample/OdbcConstants.pqm
+++ b/samples/ODBC/HiveSample/OdbcConstants.pqm
@@ -121,28 +121,28 @@ SQL_CVT =
          // from Odbcss.h
          SQL_HC =                   
     [
-        OFF = 0,                //  FOR BROWSE columns are hidden
-        ON = 1                //  FOR BROWSE columns are exposed
+        OFF = 0,                // FOR BROWSE columns are hidden
+        ON = 1                // FOR BROWSE columns are exposed
     ],
 
          // from Odbcss.h
          SQL_NB =                    
     [
-        OFF = 0,                //  NO_BROWSETABLE is off
-        ON = 1                //  NO_BROWSETABLE is on
+        OFF = 0,                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is off
     ],
 
-    //  SQLColAttributes driver specific defines.
-    //  SQLSet/GetDescField driver specific defines.
-    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    // SQLColAttributes driver specific defines.
+    // SQLSet/GetDescField driver specific defines.
+    // Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
          // from Odbcss.h
          SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
-        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
-        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        COLUMN_HIDDEN = 1200 + 11,      // Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      // Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17

--- a/samples/ODBC/RedshiftODBC/Diagnostics.pqm
+++ b/samples/ODBC/RedshiftODBC/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/ODBC/RedshiftODBC/OdbcConstants.pqm
+++ b/samples/ODBC/RedshiftODBC/OdbcConstants.pqm
@@ -66,7 +66,7 @@
 
 SQL_CVT =
 [
-    //None = 0,
+    // None = 0,
 
     CHAR = 0x00000001,
     NUMERIC = 0x00000002,
@@ -116,15 +116,17 @@ SQL_CVT =
         SMALLINT = -8
     ],
 
-    //SQL Server specific defines
+    // SQL Server specific defines
     //
-    SQL_HC =                        // from Odbcss.h
+         // from Odbcss.h
+         SQL_HC =                   
     [
         OFF = 0,                //  FOR BROWSE columns are hidden
         ON = 1                //  FOR BROWSE columns are exposed
     ],
 
-    SQL_NB =                         // from Odbcss.h
+         // from Odbcss.h
+         SQL_NB =                    
     [
         OFF = 0,                //  NO_BROWSETABLE is off
         ON = 1                //  NO_BROWSETABLE is on
@@ -134,7 +136,8 @@ SQL_CVT =
     //  SQLSet/GetDescField driver specific defines.
     //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
-    SQL_CA_SS =                      // from Odbcss.h
+         // from Odbcss.h
+         SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
@@ -146,18 +149,19 @@ SQL_CVT =
 
     ],
 
-    SQL_SOPT_SS =                    // from Odbcss.h
+         // from Odbcss.h
+         SQL_SOPT_SS =               
     [
         BASE = 1225,                // SQL_SOPT_SS_BASE
         HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
         NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
     ],
 
-    SQL_COMMIT = 0,      //Commit
-    SQL_ROLLBACK = 1,      //Abort
+    SQL_COMMIT = 0,      // Commit
+    SQL_ROLLBACK = 1,      // Abort
 
-    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
-    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+    // static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    // static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
 
     SQL_TRANSACTION =
     [
@@ -276,7 +280,7 @@ SQL_CVT =
         NESTED = 0x00000008,    // SQL_OJ_NESTED
         NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
         INNER = 0x00000020,    // SQL_OJ_INNER
-        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+        ALL_COMPARISON_OPS = 0x00000040  // SQL_OJ_ALLCOMPARISION+OPS
     ],
 
     SQL_UPDATABLE =
@@ -454,8 +458,8 @@ SQL_CVT =
         SS_TIMESTAMPOFFSET  = -155
     ],
 
-    //SQL_ALL_TYPES = 0,
-    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+    // SQL_ALL_TYPES = 0,
+    // static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
 
     SQL_LENGTH = 
     [
@@ -521,7 +525,7 @@ SQL_CVT =
 
     SQL_GD = 
     [
-        //None =  0,
+        // None =  0,
         ANY_COLUMN = 1,
         ANY_ORDER = 2,
         BLOCK = 4,
@@ -529,7 +533,7 @@ SQL_CVT =
         OUTPUT_PARAMS = 16
     ],
 
-    //SQLGetInfo
+    // SQLGetInfo
 /*
     SQL_INFO =
     [
@@ -773,7 +777,7 @@ SQL_CVT =
 
     SQL_SP = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SP_EXISTS = 0x00000001,
         SQL_SP_ISNOTNULL = 0x00000002,
@@ -902,7 +906,7 @@ SQL_CVT =
 
     SQL_FN_CVT = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_CVT_CONVERT        = 0x00000001,
         SQL_FN_CVT_CAST        = 0x00000002
@@ -910,7 +914,7 @@ SQL_CVT =
 
     SQL_FN_NUM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_NUM_ABS        = 0x00000001,
         SQL_FN_NUM_ACOS        = 0x00000002,
@@ -950,7 +954,7 @@ SQL_CVT =
 
     SQL_FN_STR =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_STR_CONCAT            = 0x00000001,
         SQL_FN_STR_INSERT            = 0x00000002,
@@ -980,7 +984,7 @@ SQL_CVT =
 
     SQL_FN_SYSTEM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_SYS_USERNAME = 0x00000001,
         SQL_FN_SYS_DBNAME = 0x00000002,
@@ -989,7 +993,7 @@ SQL_CVT =
 
     SQL_FN_TD = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_TD_NOW            = 0x00000001,
         SQL_FN_TD_CURDATE            = 0x00000002,
@@ -1023,7 +1027,7 @@ SQL_CVT =
 
     SQL_TSI =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_TSI_FRAC_SECOND = 0x00000001,
         SQL_TSI_SECOND = 0x00000002,
@@ -1038,7 +1042,7 @@ SQL_CVT =
 
     SQL_AF = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_AF_AVG        = 0x00000001,
         SQL_AF_COUNT    = 0x00000002,
@@ -1053,7 +1057,7 @@ SQL_CVT =
 
     SQL_SC = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SC_SQL92_ENTRY            = 0x00000001,
         SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
@@ -1086,7 +1090,7 @@ SQL_CVT =
         SQL_IK_NONE        = 0x00000000,
         SQL_IK_ASC        = 0x00000001,
         SQL_IK_DESC        = 0x00000002,
-        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+        SQL_IK_ALL = 0x00000003 // SQL_IK_ASC | SQL_IK_DESC
     ],
 
     SQL_ISV = 
@@ -1118,7 +1122,7 @@ SQL_CVT =
 
     SQL_SRJO = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
         SQL_SRJO_CROSS_JOIN = 0x00000002,
@@ -1140,10 +1144,11 @@ SQL_CVT =
         SQL_SRVC_ROW_SUBQUERY = 0x00000008
     ],
 
-    //public static readonly int SQL_OV_ODBC3 = 3;
-    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+    // public static readonly int SQL_OV_ODBC3 = 3;
+    // public const Int32 SQL_NTS = -3;
+    // flags for null-terminated string
 
-    //Pooling
+    // Pooling
     SQL_CP = 
     [
         OFF = 0,

--- a/samples/ODBC/RedshiftODBC/OdbcConstants.pqm
+++ b/samples/ODBC/RedshiftODBC/OdbcConstants.pqm
@@ -129,7 +129,7 @@ SQL_CVT =
          SQL_NB =                    
     [
         OFF = 0,                // NO_BROWSETABLE is off
-        ON = 1                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is on
     ],
 
     // SQLColAttributes driver specific defines.

--- a/samples/ODBC/RedshiftODBC/OdbcConstants.pqm
+++ b/samples/ODBC/RedshiftODBC/OdbcConstants.pqm
@@ -121,28 +121,28 @@ SQL_CVT =
          // from Odbcss.h
          SQL_HC =                   
     [
-        OFF = 0,                //  FOR BROWSE columns are hidden
-        ON = 1                //  FOR BROWSE columns are exposed
+        OFF = 0,                // FOR BROWSE columns are hidden
+        ON = 1                // FOR BROWSE columns are exposed
     ],
 
          // from Odbcss.h
          SQL_NB =                    
     [
-        OFF = 0,                //  NO_BROWSETABLE is off
-        ON = 1                //  NO_BROWSETABLE is on
+        OFF = 0,                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is off
     ],
 
-    //  SQLColAttributes driver specific defines.
-    //  SQLSet/GetDescField driver specific defines.
-    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    // SQLColAttributes driver specific defines.
+    // SQLSet/GetDescField driver specific defines.
+    // Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
          // from Odbcss.h
          SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
-        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
-        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        COLUMN_HIDDEN = 1200 + 11,      // Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      // Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17

--- a/samples/ODBC/SnowflakeODBC/Diagnostics.pqm
+++ b/samples/ODBC/SnowflakeODBC/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/ODBC/SnowflakeODBC/OdbcConstants.pqm
+++ b/samples/ODBC/SnowflakeODBC/OdbcConstants.pqm
@@ -66,7 +66,7 @@
 
 SQL_CVT =
 [
-    //None = 0,
+    // None = 0,
 
     CHAR = 0x00000001,
     NUMERIC = 0x00000002,
@@ -116,15 +116,17 @@ SQL_CVT =
         SMALLINT = -8
     ],
 
-    //SQL Server specific defines
+    // SQL Server specific defines
     //
-    SQL_HC =                        // from Odbcss.h
+         // from Odbcss.h
+         SQL_HC =                   
     [
         OFF = 0,                //  FOR BROWSE columns are hidden
         ON = 1                //  FOR BROWSE columns are exposed
     ],
 
-    SQL_NB =                         // from Odbcss.h
+         // from Odbcss.h
+         SQL_NB =                    
     [
         OFF = 0,                //  NO_BROWSETABLE is off
         ON = 1                //  NO_BROWSETABLE is on
@@ -134,7 +136,8 @@ SQL_CVT =
     //  SQLSet/GetDescField driver specific defines.
     //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
-    SQL_CA_SS =                      // from Odbcss.h
+         // from Odbcss.h
+         SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
@@ -146,18 +149,19 @@ SQL_CVT =
 
     ],
 
-    SQL_SOPT_SS =                    // from Odbcss.h
+         // from Odbcss.h
+         SQL_SOPT_SS =               
     [
         BASE = 1225,                // SQL_SOPT_SS_BASE
         HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
         NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
     ],
 
-    SQL_COMMIT = 0,      //Commit
-    SQL_ROLLBACK = 1,      //Abort
+    SQL_COMMIT = 0,      // Commit
+    SQL_ROLLBACK = 1,      // Abort
 
-    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
-    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+    // static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    // static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
 
     SQL_TRANSACTION =
     [
@@ -276,7 +280,7 @@ SQL_CVT =
         NESTED = 0x00000008,    // SQL_OJ_NESTED
         NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
         INNER = 0x00000020,    // SQL_OJ_INNER
-        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+        ALL_COMPARISON_OPS = 0x00000040  // SQL_OJ_ALLCOMPARISION+OPS
     ],
 
     SQL_UPDATABLE =
@@ -454,8 +458,8 @@ SQL_CVT =
         SS_TIMESTAMPOFFSET  = -155
     ],
 
-    //SQL_ALL_TYPES = 0,
-    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+    // SQL_ALL_TYPES = 0,
+    // static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
 
     SQL_LENGTH = 
     [
@@ -521,7 +525,7 @@ SQL_CVT =
 
     SQL_GD = 
     [
-        //None =  0,
+        // None =  0,
         ANY_COLUMN = 1,
         ANY_ORDER = 2,
         BLOCK = 4,
@@ -529,7 +533,7 @@ SQL_CVT =
         OUTPUT_PARAMS = 16
     ],
 
-    //SQLGetInfo
+    // SQLGetInfo
 /*
     SQL_INFO =
     [
@@ -773,7 +777,7 @@ SQL_CVT =
 
     SQL_SP = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SP_EXISTS = 0x00000001,
         SQL_SP_ISNOTNULL = 0x00000002,
@@ -902,7 +906,7 @@ SQL_CVT =
 
     SQL_FN_CVT = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_CVT_CONVERT        = 0x00000001,
         SQL_FN_CVT_CAST        = 0x00000002
@@ -910,7 +914,7 @@ SQL_CVT =
 
     SQL_FN_NUM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_NUM_ABS        = 0x00000001,
         SQL_FN_NUM_ACOS        = 0x00000002,
@@ -950,7 +954,7 @@ SQL_CVT =
 
     SQL_FN_STR =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_STR_CONCAT            = 0x00000001,
         SQL_FN_STR_INSERT            = 0x00000002,
@@ -980,7 +984,7 @@ SQL_CVT =
 
     SQL_FN_SYSTEM = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_SYS_USERNAME = 0x00000001,
         SQL_FN_SYS_DBNAME = 0x00000002,
@@ -989,7 +993,7 @@ SQL_CVT =
 
     SQL_FN_TD = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_FN_TD_NOW            = 0x00000001,
         SQL_FN_TD_CURDATE            = 0x00000002,
@@ -1023,7 +1027,7 @@ SQL_CVT =
 
     SQL_TSI =
     [
-        //None = 0,
+        // None = 0,
 
         SQL_TSI_FRAC_SECOND = 0x00000001,
         SQL_TSI_SECOND = 0x00000002,
@@ -1038,7 +1042,7 @@ SQL_CVT =
 
     SQL_AF = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_AF_AVG        = 0x00000001,
         SQL_AF_COUNT    = 0x00000002,
@@ -1053,7 +1057,7 @@ SQL_CVT =
 
     SQL_SC = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SC_SQL92_ENTRY            = 0x00000001,
         SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
@@ -1086,7 +1090,7 @@ SQL_CVT =
         SQL_IK_NONE        = 0x00000000,
         SQL_IK_ASC        = 0x00000001,
         SQL_IK_DESC        = 0x00000002,
-        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+        SQL_IK_ALL = 0x00000003 // SQL_IK_ASC | SQL_IK_DESC
     ],
 
     SQL_ISV = 
@@ -1118,7 +1122,7 @@ SQL_CVT =
 
     SQL_SRJO = 
     [
-        //None = 0,
+        // None = 0,
 
         SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
         SQL_SRJO_CROSS_JOIN = 0x00000002,
@@ -1140,10 +1144,11 @@ SQL_CVT =
         SQL_SRVC_ROW_SUBQUERY = 0x00000008
     ],
 
-    //public static readonly int SQL_OV_ODBC3 = 3;
-    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+    // public static readonly int SQL_OV_ODBC3 = 3;
+    // public const Int32 SQL_NTS = -3;
+    // flags for null-terminated string
 
-    //Pooling
+    // Pooling
     SQL_CP = 
     [
         OFF = 0,

--- a/samples/ODBC/SnowflakeODBC/OdbcConstants.pqm
+++ b/samples/ODBC/SnowflakeODBC/OdbcConstants.pqm
@@ -129,7 +129,7 @@ SQL_CVT =
          SQL_NB =                    
     [
         OFF = 0,                // NO_BROWSETABLE is off
-        ON = 1                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is on
     ],
 
     // SQLColAttributes driver specific defines.

--- a/samples/ODBC/SnowflakeODBC/OdbcConstants.pqm
+++ b/samples/ODBC/SnowflakeODBC/OdbcConstants.pqm
@@ -121,28 +121,28 @@ SQL_CVT =
          // from Odbcss.h
          SQL_HC =                   
     [
-        OFF = 0,                //  FOR BROWSE columns are hidden
-        ON = 1                //  FOR BROWSE columns are exposed
+        OFF = 0,                // FOR BROWSE columns are hidden
+        ON = 1                // FOR BROWSE columns are exposed
     ],
 
          // from Odbcss.h
          SQL_NB =                    
     [
-        OFF = 0,                //  NO_BROWSETABLE is off
-        ON = 1                //  NO_BROWSETABLE is on
+        OFF = 0,                // NO_BROWSETABLE is off
+        ON = 1                // NO_BROWSETABLE is off
     ],
 
-    //  SQLColAttributes driver specific defines.
-    //  SQLSet/GetDescField driver specific defines.
-    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    // SQLColAttributes driver specific defines.
+    // SQLSet/GetDescField driver specific defines.
+    // Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
          // from Odbcss.h
          SQL_CA_SS =                 
     [
         BASE = 1200,           // SQL_CA_SS_BASE
 
-        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
-        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        COLUMN_HIDDEN = 1200 + 11,      // Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      // Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17

--- a/samples/ODBC/SqlODBC/Diagnostics.pqm
+++ b/samples/ODBC/SqlODBC/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/ODBC/SqlODBC/OdbcConstants.pqm
+++ b/samples/ODBC/SqlODBC/OdbcConstants.pqm
@@ -112,22 +112,22 @@
     // from Odbcss.h
     SQL_NB = [
         OFF = 0,
-        //  NO_BROWSETABLE is off
+        // NO_BROWSETABLE is off
         ON = 1
-        //  NO_BROWSETABLE is on
+        // NO_BROWSETABLE is off
     ],
-    //  SQLColAttributes driver specific defines.
-    //  SQLSet/GetDescField driver specific defines.
-    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    // SQLColAttributes driver specific defines.
+    // SQLSet/GetDescField driver specific defines.
+    // Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
     // from Odbcss.h
     SQL_CA_SS = [
         BASE = 1200,
         // SQL_CA_SS_BASE
         COLUMN_HIDDEN = 1200 + 11,
-        //  Column is hidden (FOR BROWSE)
+        // Column is hidden (FOR BROWSE)
         COLUMN_KEY = 1200 + 12,
-        //  Column is key column (FOR BROWSE)
+        // Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17

--- a/samples/ODBC/SqlODBC/OdbcConstants.pqm
+++ b/samples/ODBC/SqlODBC/OdbcConstants.pqm
@@ -114,7 +114,7 @@
         OFF = 0,
         // NO_BROWSETABLE is off
         ON = 1
-        // NO_BROWSETABLE is off
+        // NO_BROWSETABLE is on
     ],
     // SQLColAttributes driver specific defines.
     // SQLSet/GetDescField driver specific defines.

--- a/samples/ODBC/SqlODBC/OdbcConstants.pqm
+++ b/samples/ODBC/SqlODBC/OdbcConstants.pqm
@@ -1,35 +1,33 @@
 // values from https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
 [
-    Flags = (flags as list) => 
-        if (List.IsEmpty(flags)) then 0 else
-        let
-            Loop = List.Generate(()=> [i = 0, Combined = flags{0}],
-                                    each [i] < List.Count(flags),
-                                    each [Combined = Number.BitwiseOr([Combined], flags{i}), i = [i]+1],
-                                    each [Combined]),
-            Result = List.Last(Loop)
-        in
-            Result,
-
-    SQL_HANDLE =
-    [
+    Flags = (flags as list) =>
+        if (List.IsEmpty(flags)) then
+            0
+        else
+            let
+                Loop = List.Generate(
+                    () => [i = 0, Combined = flags{0}],
+                    each [i] < List.Count(flags),
+                    each [Combined = Number.BitwiseOr([Combined], flags{i}), i = [i] + 1],
+                    each [Combined]
+                ),
+                Result = List.Last(Loop)
+            in
+                Result,
+    SQL_HANDLE = [
         ENV = 1,
         DBC = 2,
         STMT = 3,
         DESC = 4
     ],
-
-    RetCode =
-    [
+    RetCode = [
         SUCCESS = 0,
         SUCCESS_WITH_INFO = 1,
         ERROR = -1,
         INVALID_HANDLE = -2,
         NO_DATA = 100
     ],
-
-    SQL_CONVERT =
-    [
+    SQL_CONVERT = [
         BIGINT = 53,
         BINARY = 54,
         BIT = 55,
@@ -50,9 +48,7 @@
         VARCHAR = 70,
         LONGVARBINARY = 71
     ],
-
-    SQL_ROW =
-    [
+    SQL_ROW = [
         PROCEED = 0,
         IGNORE = 1,
         SUCCESS = 0,
@@ -63,123 +59,117 @@
         ERROR = 5,
         SUCCESS_WITH_INFO = 6
     ],
-
-SQL_CVT =
-[
-    //None = 0,
-
-    CHAR = 0x00000001,
-    NUMERIC = 0x00000002,
-    DECIMAL = 0x00000004,
-    INTEGER = 0x00000008,
-    SMALLINT = 0x00000010,
-    FLOAT = 0x00000020,
-    REAL = 0x00000040,
-    DOUBLE = 0x00000080,
-    VARCHAR = 0x00000100,
-    LONGVARCHAR = 0x00000200,
-    BINARY = 0x00000400,
-    VARBINARY = 0x00000800,
-    BIT = 0x00001000,
-    TINYINT = 0x00002000,
-    BIGINT = 0x00004000,
-    DATE = 0x00008000,
-    TIME = 0x00010000,
-    TIMESTAMP = 0x00020000,
-    LONGVARBINARY = 0x00040000,
-    INTERVAL_YEAR_MONTH = 0x00080000,
-    INTERVAL_DAY_TIME = 0x00100000,
-    WCHAR = 0x00200000,
-    WLONGVARCHAR = 0x00400000,
-    WVARCHAR = 0x00800000,
-    GUID = 0x01000000
-],
-
-    STMT =
-    [
+    SQL_CVT = [
+        // None = 0,
+        CHAR = 0x00000001,
+        NUMERIC = 0x00000002,
+        DECIMAL = 0x00000004,
+        INTEGER = 0x00000008,
+        SMALLINT = 0x00000010,
+        FLOAT = 0x00000020,
+        REAL = 0x00000040,
+        DOUBLE = 0x00000080,
+        VARCHAR = 0x00000100,
+        LONGVARCHAR = 0x00000200,
+        BINARY = 0x00000400,
+        VARBINARY = 0x00000800,
+        BIT = 0x00001000,
+        TINYINT = 0x00002000,
+        BIGINT = 0x00004000,
+        DATE = 0x00008000,
+        TIME = 0x00010000,
+        TIMESTAMP = 0x00020000,
+        LONGVARBINARY = 0x00040000,
+        INTERVAL_YEAR_MONTH = 0x00080000,
+        INTERVAL_DAY_TIME = 0x00100000,
+        WCHAR = 0x00200000,
+        WLONGVARCHAR = 0x00400000,
+        WVARCHAR = 0x00800000,
+        GUID = 0x01000000
+    ],
+    STMT = [
         CLOSE = 0,
         DROP = 1,
         UNBIND = 2,
         RESET_PARAMS = 3
     ],
-
-    SQL_MAX =
-    [
+    SQL_MAX = [
         NUMERIC_LEN = 16
     ],
-
-    SQL_IS =
-    [
+    SQL_IS = [
         POINTER = -4,
         INTEGER = -6,
         UINTEGER = -5,
         SMALLINT = -8
     ],
-
-    //SQL Server specific defines
+    // SQL Server specific defines
     //
-    SQL_HC =                        // from Odbcss.h
-    [
-        OFF = 0,                //  FOR BROWSE columns are hidden
-        ON = 1                //  FOR BROWSE columns are exposed
+    // from Odbcss.h
+    SQL_HC = [
+        OFF = 0 /*  FOR BROWSE columns are hidden */,
+        ON = 1 /* FOR BROWSE columns are exposed */
     ],
-
-    SQL_NB =                         // from Odbcss.h
-    [
-        OFF = 0,                //  NO_BROWSETABLE is off
-        ON = 1                //  NO_BROWSETABLE is on
+    // from Odbcss.h
+    SQL_NB = [
+        OFF = 0,
+        //  NO_BROWSETABLE is off
+        ON = 1
+        //  NO_BROWSETABLE is on
     ],
-
     //  SQLColAttributes driver specific defines.
     //  SQLSet/GetDescField driver specific defines.
     //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
     //
-    SQL_CA_SS =                      // from Odbcss.h
-    [
-        BASE = 1200,           // SQL_CA_SS_BASE
-
-        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
-        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+    // from Odbcss.h
+    SQL_CA_SS = [
+        BASE = 1200,
+        // SQL_CA_SS_BASE
+        COLUMN_HIDDEN = 1200 + 11,
+        //  Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,
+        //  Column is key column (FOR BROWSE)
         VARIANT_TYPE = 1200 + 15,
         VARIANT_SQL_TYPE = 1200 + 16,
         VARIANT_SERVER_TYPE = 1200 + 17
-
     ],
-
-    SQL_SOPT_SS =                    // from Odbcss.h
-    [
-        BASE = 1225,                // SQL_SOPT_SS_BASE
-        HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
-        NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
+    // from Odbcss.h
+    SQL_SOPT_SS = [
+        BASE = 1225,
+        // SQL_SOPT_SS_BASE
+        HIDDEN_COLUMNS = 1225 + 2,
+        // Expose FOR BROWSE hidden columns
+        NOBROWSETABLE = 1225 + 3
+        // Set NOBROWSETABLE option
     ],
-
-    SQL_COMMIT = 0,      //Commit
-    SQL_ROLLBACK = 1,      //Abort
-
-    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
-    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
-
-    SQL_TRANSACTION =
-    [
+    SQL_COMMIT = 0,
+    // Commit
+    SQL_ROLLBACK = 1,
+    // Abort
+    // static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    // static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+    SQL_TRANSACTION = [
         READ_UNCOMMITTED = 0x00000001,
         READ_COMMITTED = 0x00000002,
         REPEATABLE_READ = 0x00000004,
         SERIALIZABLE = 0x00000008,
-        SNAPSHOT = 0x00000020 // VSDD 414121: SQL_TXN_SS_SNAPSHOT == 0x20 (sqlncli.h)
+        SNAPSHOT = 0x00000020
+        // VSDD 414121: SQL_TXN_SS_SNAPSHOT == 0x20 (sqlncli.h)
     ],
-
-    SQL_PARAM =
-    [
-        TYPE_UNKNOWN = 0,          // SQL_PARAM_TYPE_UNKNOWN
-        INPUT = 1,                 // SQL_PARAM_INPUT
-        INPUT_OUTPUT = 2,          // SQL_PARAM_INPUT_OUTPUT
-        RESULT_COL =   3,          // SQL_RESULT_COL
-        OUTPUT = 4,                // SQL_PARAM_OUTPUT
-        RETURN_VALUE = 5           // SQL_RETURN_VALUE
+    SQL_PARAM = [
+        TYPE_UNKNOWN = 0,
+        // SQL_PARAM_TYPE_UNKNOWN
+        INPUT = 1,
+        // SQL_PARAM_INPUT
+        INPUT_OUTPUT = 2,
+        // SQL_PARAM_INPUT_OUTPUT
+        RESULT_COL = 3,
+        // SQL_RESULT_COL
+        OUTPUT = 4,
+        // SQL_PARAM_OUTPUT
+        RETURN_VALUE = 5
+        // SQL_RETURN_VALUE
     ],
-
-    SQL_DESC =
-    [
+    SQL_DESC = [
         // from sql.h (ODBCVER >= 3.0)
         //
         COUNT = 1001,
@@ -196,7 +186,6 @@ SQL_CVT =
         UNNAMED = 1012,
         OCTET_LENGTH = 1013,
         ALLOC_TYPE = 1099,
-
         // from sqlext.h (ODBCVER >= 3.0)
         //
         CONCISE_TYPE = SQL_COLUMN[TYPE],
@@ -204,23 +193,18 @@ SQL_CVT =
         UNSIGNED = SQL_COLUMN[UNSIGNED],
         UPDATABLE = SQL_COLUMN[UPDATABLE],
         AUTO_UNIQUE_VALUE = SQL_COLUMN[AUTO_INCREMENT],
-
         TYPE_NAME = SQL_COLUMN[TYPE_NAME],
         TABLE_NAME = SQL_COLUMN[TABLE_NAME],
         SCHEMA_NAME = SQL_COLUMN[OWNER_NAME],
         CATALOG_NAME = SQL_COLUMN[QUALIFIER_NAME],
-
         BASE_COLUMN_NAME = 22,
         BASE_TABLE_NAME = 23,
-
         NUM_PREC_RADIX = 32
     ],
-
     // ODBC version 2.0 style attributes
     // All IdentifierValues are ODBC 1.0 unless marked differently
     //
-    SQL_COLUMN =
-    [
+    SQL_COLUMN = [
         COUNT = 0,
         NAME = 1,
         TYPE = 2,
@@ -236,229 +220,241 @@ SQL_CVT =
         CASE_SENSITIVE = 12,
         SEARCHABLE = 13,
         TYPE_NAME = 14,
-        TABLE_NAME = 15,    // (ODBC 2.0)
-        OWNER_NAME = 16,    // (ODBC 2.0)
-        QUALIFIER_NAME = 17,    // (ODBC 2.0)
+        TABLE_NAME = 15,
+        // (ODBC 2.0)
+        OWNER_NAME = 16,
+        // (ODBC 2.0)
+        QUALIFIER_NAME = 17,
+        // (ODBC 2.0)
         LABEL = 18
     ],
-
     // values from sqlext.h
-    SQL_SQL92_RELATIONAL_JOIN_OPERATORS =
-    [
-        CORRESPONDING_CLAUSE = 0x00000001,    // SQL_SRJO_CORRESPONDING_CLAUSE
-        CROSS_JOIN = 0x00000002,    // SQL_SRJO_CROSS_JOIN
-        EXCEPT_JOIN = 0x00000004,    // SQL_SRJO_EXCEPT_JOIN
-        FULL_OUTER_JOIN = 0x00000008,    // SQL_SRJO_FULL_OUTER_JOIN
-        INNER_JOIN = 0x00000010,    // SQL_SRJO_INNER_JOIN
-        INTERSECT_JOIN = 0x00000020,    // SQL_SRJO_INTERSECT_JOIN
-        LEFT_OUTER_JOIN = 0x00000040,    // SQL_SRJO_LEFT_OUTER_JOIN
-        NATURAL_JOIN = 0x00000080,    // SQL_SRJO_NATURAL_JOIN
-        RIGHT_OUTER_JOIN = 0x00000100,  // SQL_SRJO_RIGHT_OUTER_JOIN
-        UNION_JOIN = 0x00000200         // SQL_SRJO_UNION_JOIN
+    SQL_SQL92_RELATIONAL_JOIN_OPERATORS = [
+        CORRESPONDING_CLAUSE = 0x00000001,
+        // SQL_SRJO_CORRESPONDING_CLAUSE
+        CROSS_JOIN = 0x00000002,
+        // SQL_SRJO_CROSS_JOIN
+        EXCEPT_JOIN = 0x00000004,
+        // SQL_SRJO_EXCEPT_JOIN
+        FULL_OUTER_JOIN = 0x00000008,
+        // SQL_SRJO_FULL_OUTER_JOIN
+        INNER_JOIN = 0x00000010,
+        // SQL_SRJO_INNER_JOIN
+        INTERSECT_JOIN = 0x00000020,
+        // SQL_SRJO_INTERSECT_JOIN
+        LEFT_OUTER_JOIN = 0x00000040,
+        // SQL_SRJO_LEFT_OUTER_JOIN
+        NATURAL_JOIN = 0x00000080,
+        // SQL_SRJO_NATURAL_JOIN
+        RIGHT_OUTER_JOIN = 0x00000100,
+        // SQL_SRJO_RIGHT_OUTER_JOIN
+        UNION_JOIN = 0x00000200
+        // SQL_SRJO_UNION_JOIN
     ],
-
     // values from sqlext.h
-    SQL_QU = 
-    [
+    SQL_QU = [
         SQL_QU_DML_STATEMENTS = 0x00000001,
         SQL_QU_PROCEDURE_INVOCATION = 0x00000002,
-        SQL_QU_TABLE_DEFINITION     = 0x00000004,
-        SQL_QU_INDEX_DEFINITION     = 0x00000008,
+        SQL_QU_TABLE_DEFINITION = 0x00000004,
+        SQL_QU_INDEX_DEFINITION = 0x00000008,
         SQL_QU_PRIVILEGE_DEFINITION = 0x00000010
     ],
-
     // values from sql.h
-    SQL_OJ_CAPABILITIES =
-    [
-        LEFT = 0x00000001,    // SQL_OJ_LEFT
-        RIGHT = 0x00000002,    // SQL_OJ_RIGHT
-        FULL = 0x00000004,    // SQL_OJ_FULL
-        NESTED = 0x00000008,    // SQL_OJ_NESTED
-        NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
-        INNER = 0x00000020,    // SQL_OJ_INNER
-        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+    SQL_OJ_CAPABILITIES = [
+        LEFT = 0x00000001,
+        // SQL_OJ_LEFT
+        RIGHT = 0x00000002,
+        // SQL_OJ_RIGHT
+        FULL = 0x00000004,
+        // SQL_OJ_FULL
+        NESTED = 0x00000008,
+        // SQL_OJ_NESTED
+        NOT_ORDERED = 0x00000010,
+        // SQL_OJ_NOT_ORDERED
+        INNER = 0x00000020,
+        // SQL_OJ_INNER
+        ALL_COMPARISON_OPS = 0x00000040
+        // SQL_OJ_ALLCOMPARISION+OPS
     ],
-
-    SQL_UPDATABLE =
-    [
-        READONLY = 0,          // SQL_ATTR_READ_ONLY
-        WRITE = 1,             // SQL_ATTR_WRITE
-        READWRITE_UNKNOWN = 2  // SQL_ATTR_READWRITE_UNKNOWN
+    SQL_UPDATABLE = [
+        READONLY = 0,
+        // SQL_ATTR_READ_ONLY
+        WRITE = 1,
+        // SQL_ATTR_WRITE
+        READWRITE_UNKNOWN = 2
+        // SQL_ATTR_READWRITE_UNKNOWN
     ],
-
-    SQL_IDENTIFIER_CASE =
-    [
-        UPPER = 1,    // SQL_IC_UPPER
-        LOWER = 2,    // SQL_IC_LOWER
-        SENSITIVE = 3,    // SQL_IC_SENSITIVE
-        MIXED = 4    // SQL_IC_MIXED
+    SQL_IDENTIFIER_CASE = [
+        UPPER = 1,
+        // SQL_IC_UPPER
+        LOWER = 2,
+        // SQL_IC_LOWER
+        SENSITIVE = 3,
+        // SQL_IC_SENSITIVE
+        MIXED = 4
+        // SQL_IC_MIXED
     ],
-
     // Uniqueness parameter in the SQLStatistics function
-    SQL_INDEX =
-    [
+    SQL_INDEX = [
         UNIQUE = 0,
         ALL = 1
     ],
-
     // Reserved parameter in the SQLStatistics function
-    SQL_STATISTICS_RESERVED =
-    [
-        QUICK = 0,                // SQL_QUICK
-        ENSURE = 1                // SQL_ENSURE
+    SQL_STATISTICS_RESERVED = [
+        QUICK = 0,
+        // SQL_QUICK
+        ENSURE = 1
+        // SQL_ENSURE
     ],
-
     // Identifier type parameter in the SQLSpecialColumns function
-    SQL_SPECIALCOLS =
-    [
-        BEST_ROWID = 1,            // SQL_BEST_ROWID
-        ROWVER = 2            // SQL_ROWVER
+    SQL_SPECIALCOLS = [
+        BEST_ROWID = 1,
+        // SQL_BEST_ROWID
+        ROWVER = 2
+        // SQL_ROWVER
     ],
-
     // Scope parameter in the SQLSpecialColumns function
-    SQL_SCOPE =
-    [
-        CURROW = 0,            // SQL_SCOPE_CURROW
-        TRANSACTION = 1,           // SQL_SCOPE_TRANSACTION
-        SESSION = 2           // SQL_SCOPE_SESSION
+    SQL_SCOPE = [
+        CURROW = 0,
+        // SQL_SCOPE_CURROW
+        TRANSACTION = 1,
+        // SQL_SCOPE_TRANSACTION
+        SESSION = 2
+        // SQL_SCOPE_SESSION
     ],
-
-    SQL_NULLABILITY =
-    [
-        NO_NULLS = 0,                // SQL_NO_NULLS
-        NULLABLE = 1,                // SQL_NULLABLE
-        UNKNOWN = 2                 // SQL_NULLABLE_UNKNOWN
+    SQL_NULLABILITY = [
+        NO_NULLS = 0,
+        // SQL_NO_NULLS
+        NULLABLE = 1,
+        // SQL_NULLABLE
+        UNKNOWN = 2
+        // SQL_NULLABLE_UNKNOWN
     ],
-
-    SQL_SEARCHABLE =
-    [
-        UNSEARCHABLE = 0,        // SQL_UNSEARCHABLE
-        LIKE_ONLY = 1,        // SQL_LIKE_ONLY
-        ALL_EXCEPT_LIKE = 2,        // SQL_ALL_EXCEPT_LIKE
-        SEARCHABLE = 3        // SQL_SEARCHABLE
+    SQL_SEARCHABLE = [
+        UNSEARCHABLE = 0,
+        // SQL_UNSEARCHABLE
+        LIKE_ONLY = 1,
+        // SQL_LIKE_ONLY
+        ALL_EXCEPT_LIKE = 2,
+        // SQL_ALL_EXCEPT_LIKE
+        SEARCHABLE = 3
+        // SQL_SEARCHABLE
     ],
-
-    SQL_UNNAMED =
-    [
-        NAMED = 0,                   // SQL_NAMED
-        UNNAMED = 1                  // SQL_UNNAMED
+    SQL_UNNAMED = [
+        NAMED = 0,
+        // SQL_NAMED
+        UNNAMED = 1
+        // SQL_UNNAMED
     ],
     // todo:move
     // internal constants
     // not odbc specific
     //
-    HANDLER =
-    [
+    HANDLER = [
         IGNORE = 0x00000000,
         THROW = 0x00000001
     ],
-
     // values for SQLStatistics TYPE column
-    SQL_STATISTICSTYPE =
-    [
-        TABLE_STAT = 0,                    // TABLE Statistics
-        INDEX_CLUSTERED = 1,               // CLUSTERED index statistics
-        INDEX_HASHED = 2,                  // HASHED index statistics
-        INDEX_OTHER = 3                    // OTHER index statistics
+    SQL_STATISTICSTYPE = [
+        TABLE_STAT = 0,
+        // TABLE Statistics
+        INDEX_CLUSTERED = 1,
+        // CLUSTERED index statistics
+        INDEX_HASHED = 2,
+        // HASHED index statistics
+        INDEX_OTHER = 3
+        // OTHER index statistics
     ],
-
     // values for SQLProcedures PROCEDURE_TYPE column
-    SQL_PROCEDURETYPE =
-    [
-        UNKNOWN = 0,                    // procedure is of unknow type
-        PROCEDURE = 1,                    // procedure is a procedure
-        FUNCTION = 2                     // procedure is a function
+    SQL_PROCEDURETYPE = [
+        UNKNOWN = 0,
+        // procedure is of unknow type
+        PROCEDURE = 1,
+        // procedure is a procedure
+        FUNCTION = 2
+        // procedure is a function
     ],
-
     // private constants
     // to define data types (see below)
     //
-    SIGNED_OFFSET = -20,      // SQL_SIGNED_OFFSET
-    UNSIGNED_OFFSET = -22,    // SQL_UNSIGNED_OFFSET
-
+    SIGNED_OFFSET = -20,
+    // SQL_SIGNED_OFFSET
+    UNSIGNED_OFFSET = -22,
+    // SQL_UNSIGNED_OFFSET
     // C Data Types
-    SQL_C =
-    [
-        CHAR            = 1,
-        WCHAR           = -8,
-        SLONG           = 4     + SIGNED_OFFSET,
-        ULONG           = 4     + UNSIGNED_OFFSET,
-        SSHORT          = 5     + SIGNED_OFFSET,
-        USHORT          = 5     + UNSIGNED_OFFSET,
-        FLOAT           = 7,
-        DOUBLE          = 8,
-        BIT             = -7,
-        STINYINT        = -6    + SIGNED_OFFSET,
-        UTINYINT        = -6    + UNSIGNED_OFFSET,
-        SBIGINT         = -5    + SIGNED_OFFSET,
-        UBIGINT         = -5    + UNSIGNED_OFFSET,
-        BINARY          = -2,
-        TIMESTAMP       = 11,
-
-        TYPE_DATE       = 91,
-        TYPE_TIME       = 92,
-        TYPE_TIMESTAMP  = 93,
-
-        NUMERIC         = 2,
-        GUID            = -11,
-        DEFAULT         = 99,
-        ARD_TYPE        = -99
+    SQL_C = [
+        CHAR = 1,
+        WCHAR = -8,
+        SLONG = 4 + SIGNED_OFFSET,
+        ULONG = 4 + UNSIGNED_OFFSET,
+        SSHORT = 5 + SIGNED_OFFSET,
+        USHORT = 5 + UNSIGNED_OFFSET,
+        FLOAT = 7,
+        DOUBLE = 8,
+        BIT = -7,
+        STINYINT = -6 + SIGNED_OFFSET,
+        UTINYINT = -6 + UNSIGNED_OFFSET,
+        SBIGINT = -5 + SIGNED_OFFSET,
+        UBIGINT = -5 + UNSIGNED_OFFSET,
+        BINARY = -2,
+        TIMESTAMP = 11,
+        TYPE_DATE = 91,
+        TYPE_TIME = 92,
+        TYPE_TIMESTAMP = 93,
+        NUMERIC = 2,
+        GUID = -11,
+        DEFAULT = 99,
+        ARD_TYPE = -99
     ],
-
     // SQL Data Types
-    SQL_TYPE =
-    [
+    SQL_TYPE = [
         // Base data types (sql.h)
-        UNKNOWN             = 0,
-        NULL                = 0,
-        CHAR                = 1,
-        NUMERIC             = 2,
-        DECIMAL             = 3,
-        INTEGER             = 4,
-        SMALLINT            = 5,
-        FLOAT               = 6,
-        REAL                = 7,
-        DOUBLE              = 8,
-        DATETIME            = 9,      // V3 Only
-        VARCHAR             = 12,
-
+        UNKNOWN = 0,
+        NULL = 0,
+        CHAR = 1,
+        NUMERIC = 2,
+        DECIMAL = 3,
+        INTEGER = 4,
+        SMALLINT = 5,
+        FLOAT = 6,
+        REAL = 7,
+        DOUBLE = 8,
+        DATETIME = 9,
+        // V3 Only
+        VARCHAR = 12,
         // Unicode types (sqlucode.h)
-        WCHAR               = -8,
-        WVARCHAR            = -9,
-        WLONGVARCHAR        = -10,
-
+        WCHAR = -8,
+        WVARCHAR = -9,
+        WLONGVARCHAR = -10,
         // Extended data types (sqlext.h)
-        INTERVAL            = 10,    // V3 Only
-        TIME                = 10,
-        TIMESTAMP           = 11,
-        LONGVARCHAR         = -1,
-        BINARY              = -2,
-        VARBINARY           = -3,
-        LONGVARBINARY       = -4,
-        BIGINT              = -5,
-        TINYINT             = -6,
-        BIT                 = -7,
-        GUID                = -11,   // V3 Only
-
+        INTERVAL = 10,
+        // V3 Only
+        TIME = 10,
+        TIMESTAMP = 11,
+        LONGVARCHAR = -1,
+        BINARY = -2,
+        VARBINARY = -3,
+        LONGVARBINARY = -4,
+        BIGINT = -5,
+        TINYINT = -6,
+        BIT = -7,
+        GUID = -11,
+        // V3 Only
         // One-parameter shortcuts for date/time data types.
-        TYPE_DATE           = 91,
-        TYPE_TIME           = 92,
-        TYPE_TIMESTAMP      = 93,
-
+        TYPE_DATE = 91,
+        TYPE_TIME = 92,
+        TYPE_TIMESTAMP = 93,
         // SQL Server Types -150 to -159 (sqlncli.h)
-        SS_VARIANT          = -150,
-        SS_UDT              = -151,
-        SS_XML              = -152,
-        SS_TABLE            = -153,
-        SS_TIME2            = -154,
-        SS_TIMESTAMPOFFSET  = -155
+        SS_VARIANT = -150,
+        SS_UDT = -151,
+        SS_XML = -152,
+        SS_TABLE = -153,
+        SS_TIME2 = -154,
+        SS_TIMESTAMPOFFSET = -155
     ],
-
-    //SQL_ALL_TYPES = 0,
-    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
-
-    SQL_LENGTH = 
-    [
+    // SQL_ALL_TYPES = 0,
+    // static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+    SQL_LENGTH = [
         SQL_IGNORE = -6,
         SQL_DEFAULT_PARAM = -5,
         SQL_NO_TOTAL = -4,
@@ -466,9 +462,7 @@ SQL_CVT =
         SQL_DATA_AT_EXEC = -2,
         SQL_NULL_DATA = -1
     ],
-
-    SQL_DEFAULT_PARAM = -5,        
-
+    SQL_DEFAULT_PARAM = -5,
     // column ordinals for SQLProcedureColumns result set
     // this column ordinals are not defined in any c/c++ header but in the ODBC Programmer's Reference under SQLProcedureColumns
     //
@@ -478,9 +472,7 @@ SQL_CVT =
     COLUMN_SIZE = 8,
     DECIMAL_DIGITS = 10,
     NUM_PREC_RADIX = 11,
-
-    SQL_ATTR = 
-    [
+    SQL_ATTR = [
         ODBC_VERSION = 200,
         CONNECTION_POOLING = 201,
         AUTOCOMMIT = 102,
@@ -489,48 +481,39 @@ SQL_CVT =
         LOGIN_TIMEOUT = 103,
         QUERY_TIMEOUT = 0,
         CONNECTION_DEAD = 1209,
-
         SQL_COPT_SS_BASE = 1200,
         SQL_COPT_SS_ENLIST_IN_DTC = (1200 + 7),
         SQL_COPT_SS_TXN_ISOLATION = (1200 + 27),
-
         MAX_LENGTH = 3,
         ROW_BIND_TYPE = 5,
         CURSOR_TYPE = 6,
         RETRIEVE_DATA = 11,
-        ROW_STATUS_PTR = 25, 
+        ROW_STATUS_PTR = 25,
         ROWS_FETCHED_PTR = 26,
         ROW_ARRAY_SIZE = 27,
-
         // ODBC 3.0
         APP_ROW_DESC = 10010,
         APP_PARAM_DESC = 10011,
         IMP_ROW_DESC = 10012,
         IMP_PARAM_DESC = 10013,
         METADATA_ID = 10014,
-
         // ODBC 4.0
         PRIVATE_DRIVER_LOCATION = 204
     ],
-
-    SQL_RD = 
-    [
+    SQL_RD = [
         OFF = 0,
         ON = 1
     ],
-
-    SQL_GD = 
-    [
-        //None =  0,
+    SQL_GD = [
+        // None =  0,
         ANY_COLUMN = 1,
         ANY_ORDER = 2,
         BLOCK = 4,
         BOUND = 8,
         OUTPUT_PARAMS = 16
     ],
-
-    //SQLGetInfo
-/*
+    // SQLGetInfo
+    /*
     SQL_INFO =
     [
         SQL_ACTIVE_CONNECTIONS = 0,        
@@ -731,36 +714,27 @@ SQL_CVT =
         SQL_DTC_TRANSITION_COST = 1750,
     ],
 */
-    SQL_OAC = 
-    [
+    SQL_OAC = [
         SQL_OAC_None = 0x0000,
         SQL_OAC_LEVEL1 = 0x0001,
         SQL_OAC_LEVEL2 = 0x0002
     ],
-
-    SQL_OSC = 
-    [
+    SQL_OSC = [
         SQL_OSC_MINIMUM = 0x0000,
         SQL_OSC_CORE = 0x0001,
         SQL_OSC_EXTENDED = 0x0002
     ],
-
-    SQL_SCC = 
-    [
+    SQL_SCC = [
         SQL_SCC_XOPEN_CLI_VERSION1 = 0x00000001,
         SQL_SCC_ISO92_CLI = 0x00000002
     ],
-
-    SQL_SVE = 
-    [
+    SQL_SVE = [
         SQL_SVE_CASE = 0x00000001,
         SQL_SVE_CAST = 0x00000002,
         SQL_SVE_COALESCE = 0x00000004,
         SQL_SVE_NULLIF = 0x00000008
     ],
-
-    SQL_SSF = 
-    [
+    SQL_SSF = [
         SQL_SSF_CONVERT = 0x00000001,
         SQL_SSF_LOWER = 0x00000002,
         SQL_SSF_UPPER = 0x00000004,
@@ -770,11 +744,8 @@ SQL_CVT =
         SQL_SSF_TRIM_LEADING = 0x00000040,
         SQL_SSF_TRIM_TRAILING = 0x00000080
     ],
-
-    SQL_SP = 
-    [
-        //None = 0,
-
+    SQL_SP = [
+        // None = 0,
         SQL_SP_EXISTS = 0x00000001,
         SQL_SP_ISNOTNULL = 0x00000002,
         SQL_SP_ISNULL = 0x00000004,
@@ -789,65 +760,47 @@ SQL_CVT =
         SQL_SP_BETWEEN = 0x00000800,
         SQL_SP_COMPARISON = 0x00001000,
         SQL_SP_QUANTIFIED_COMPARISON = 0x00002000,
-
         All = 0x0000FFFF
     ],
-
-    SQL_OIC =
-    [
+    SQL_OIC = [
         SQL_OIC_CORE = 1,
         SQL_OIC_LEVEL1 = 2,
         SQL_OIC_LEVEL2 = 3
     ],
-
-    SQL_USAGE = 
-    [
+    SQL_USAGE = [
         SQL_U_DML_STATEMENTS = 0x00000001,
         SQL_U_PROCEDURE_INVOCATION = 0x00000002,
         SQL_U_TABLE_DEFINITION = 0x00000004,
         SQL_U_INDEX_DEFINITION = 0x00000008,
         SQL_U_PRIVILEGE_DEFINITION = 0x00000010
     ],
-
-    SQL_GB = 
-    [
-            
+    SQL_GB = [
         SQL_GB_NOT_SUPPORTED = 0,
         SQL_GB_GROUP_BY_EQUALS_SELECT = 1,
         SQL_GB_GROUP_BY_CONTAINS_SELECT = 2,
         SQL_GB_NO_RELATION = 3,
         SQL_GB_COLLATE = 4
     ],
-
-    SQL_NC =
-    [
+    SQL_NC = [
         SQL_NC_END = 0,
         SQL_NC_HIGH = 1,
         SQL_NC_LOW = 2,
         SQL_NC_START = 3
     ],
-
-    SQL_CN =
-    [
+    SQL_CN = [
         SQL_CN_None = 0,
         SQL_CN_DIFFERENT = 1,
         SQL_CN_ANY = 2
     ],
-
-    SQL_NNC = 
-    [
+    SQL_NNC = [
         SQL_NNC_NULL = 0,
         SQL_NNC_NON_NULL = 1
     ],
-
-    SQL_CB = 
-    [
+    SQL_CB = [
         SQL_CB_NULL = 0,
         SQL_CB_NON_NULL = 1
     ],
-
-    SQL_FD_FETCH = 
-    [
+    SQL_FD_FETCH = [
         SQL_FD_FETCH_NEXT = 0x00000001,
         SQL_FD_FETCH_FIRST = 0x00000002,
         SQL_FD_FETCH_LAST = 0x00000004,
@@ -856,24 +809,18 @@ SQL_CVT =
         SQL_FD_FETCH_RELATIVE = 0x00000020,
         SQL_FD_FETCH_BOOKMARK = 0x00000080
     ],
-
-    SQL_SQ = 
-    [
+    SQL_SQ = [
         SQL_SQ_COMPARISON = 0x00000001,
         SQL_SQ_EXISTS = 0x00000002,
         SQL_SQ_IN = 0x00000004,
         SQL_SQ_QUANTIFIED = 0x00000008,
         SQL_SQ_CORRELATED_SUBQUERIES = 0x00000010
     ],
-
-    SQL_U = 
-    [
+    SQL_U = [
         SQL_U_UNION = 0x00000001,
         SQL_U_UNION_ALL = 0x00000002
     ],
-
-    SQL_BP = 
-    [
+    SQL_BP = [
         SQL_BP_CLOSE = 0x00000001,
         SQL_BP_DELETE = 0x00000002,
         SQL_BP_DROP = 0x00000004,
@@ -882,15 +829,11 @@ SQL_CVT =
         SQL_BP_OTHER_HSTMT = 0x00000020,
         SQL_BP_SCROLL = 0x00000040
     ],
-
-    SQL_QL = 
-    [
+    SQL_QL = [
         SQL_QL_START = 0x0001,
         SQL_QL_END = 0x0002
     ],
-
-    SQL_OJ = 
-    [
+    SQL_OJ = [
         SQL_OJ_LEFT = 0x00000001,
         SQL_OJ_RIGHT = 0x00000002,
         SQL_OJ_FULL = 0x00000004,
@@ -899,47 +842,39 @@ SQL_CVT =
         SQL_OJ_INNER = 0x00000020,
         SQL_OJ_ALL_COMPARISON_OPS = 0x00000040
     ],
-
-    SQL_FN_CVT = 
-    [
-        //None = 0,
-
-        SQL_FN_CVT_CONVERT        = 0x00000001,
-        SQL_FN_CVT_CAST        = 0x00000002
+    SQL_FN_CVT = [
+        // None = 0,
+        SQL_FN_CVT_CONVERT = 0x00000001,
+        SQL_FN_CVT_CAST = 0x00000002
     ],
-
-    SQL_FN_NUM = 
-    [
-        //None = 0,
-
-        SQL_FN_NUM_ABS        = 0x00000001,
-        SQL_FN_NUM_ACOS        = 0x00000002,
-        SQL_FN_NUM_ASIN        = 0x00000004,
-        SQL_FN_NUM_ATAN        = 0x00000008,
-        SQL_FN_NUM_ATAN2    = 0x00000010,
-        SQL_FN_NUM_CEILING    = 0x00000020,
-        SQL_FN_NUM_COS        = 0x00000040,
-        SQL_FN_NUM_COT        = 0x00000080,
-        SQL_FN_NUM_EXP        = 0x00000100,
-        SQL_FN_NUM_FLOOR    = 0x00000200,
-        SQL_FN_NUM_LOG        = 0x00000400,
-        SQL_FN_NUM_MOD        = 0x00000800,
-        SQL_FN_NUM_SIGN        = 0x00001000,
-        SQL_FN_NUM_SIN        = 0x00002000,
-        SQL_FN_NUM_SQRT        = 0x00004000,
-        SQL_FN_NUM_TAN      = 0x00008000,
-        SQL_FN_NUM_PI       = 0x00010000,
-        SQL_FN_NUM_RAND     = 0x00020000,
-        SQL_FN_NUM_DEGREES    = 0x00040000,
-        SQL_FN_NUM_LOG10    = 0x00080000,
-        SQL_FN_NUM_POWER    = 0x00100000,
-        SQL_FN_NUM_RADIANS    = 0x00200000,
-        SQL_FN_NUM_ROUND    = 0x00400000,
+    SQL_FN_NUM = [
+        // None = 0,
+        SQL_FN_NUM_ABS = 0x00000001,
+        SQL_FN_NUM_ACOS = 0x00000002,
+        SQL_FN_NUM_ASIN = 0x00000004,
+        SQL_FN_NUM_ATAN = 0x00000008,
+        SQL_FN_NUM_ATAN2 = 0x00000010,
+        SQL_FN_NUM_CEILING = 0x00000020,
+        SQL_FN_NUM_COS = 0x00000040,
+        SQL_FN_NUM_COT = 0x00000080,
+        SQL_FN_NUM_EXP = 0x00000100,
+        SQL_FN_NUM_FLOOR = 0x00000200,
+        SQL_FN_NUM_LOG = 0x00000400,
+        SQL_FN_NUM_MOD = 0x00000800,
+        SQL_FN_NUM_SIGN = 0x00001000,
+        SQL_FN_NUM_SIN = 0x00002000,
+        SQL_FN_NUM_SQRT = 0x00004000,
+        SQL_FN_NUM_TAN = 0x00008000,
+        SQL_FN_NUM_PI = 0x00010000,
+        SQL_FN_NUM_RAND = 0x00020000,
+        SQL_FN_NUM_DEGREES = 0x00040000,
+        SQL_FN_NUM_LOG10 = 0x00080000,
+        SQL_FN_NUM_POWER = 0x00100000,
+        SQL_FN_NUM_RADIANS = 0x00200000,
+        SQL_FN_NUM_ROUND = 0x00400000,
         SQL_FN_NUM_TRUNCATE = 0x00800000
     ],
-
-    SQL_SNVF = 
-    [
+    SQL_SNVF = [
         SQL_SNVF_BIT_LENGTH = 0x00000001,
         SQL_SNVF_CHAR_LENGTH = 0x00000002,
         SQL_SNVF_CHARACTER_LENGTH = 0x00000004,
@@ -947,84 +882,70 @@ SQL_CVT =
         SQL_SNVF_OCTET_LENGTH = 0x00000010,
         SQL_SNVF_POSITION = 0x00000020
     ],
-
-    SQL_FN_STR =
-    [
-        //None = 0,
-
-        SQL_FN_STR_CONCAT            = 0x00000001,
-        SQL_FN_STR_INSERT            = 0x00000002,
-        SQL_FN_STR_LEFT            = 0x00000004,
-        SQL_FN_STR_LTRIM            = 0x00000008,
-        SQL_FN_STR_LENGTH            = 0x00000010,
-        SQL_FN_STR_LOCATE            = 0x00000020,
-        SQL_FN_STR_LCASE            = 0x00000040,
-        SQL_FN_STR_REPEAT            = 0x00000080,
-        SQL_FN_STR_REPLACE            = 0x00000100,
-        SQL_FN_STR_RIGHT            = 0x00000200,
-        SQL_FN_STR_RTRIM            = 0x00000400,
-        SQL_FN_STR_SUBSTRING        = 0x00000800,
-        SQL_FN_STR_UCASE            = 0x00001000,
-        SQL_FN_STR_ASCII            = 0x00002000,
-        SQL_FN_STR_CHAR            = 0x00004000,
+    SQL_FN_STR = [
+        // None = 0,
+        SQL_FN_STR_CONCAT = 0x00000001,
+        SQL_FN_STR_INSERT = 0x00000002,
+        SQL_FN_STR_LEFT = 0x00000004,
+        SQL_FN_STR_LTRIM = 0x00000008,
+        SQL_FN_STR_LENGTH = 0x00000010,
+        SQL_FN_STR_LOCATE = 0x00000020,
+        SQL_FN_STR_LCASE = 0x00000040,
+        SQL_FN_STR_REPEAT = 0x00000080,
+        SQL_FN_STR_REPLACE = 0x00000100,
+        SQL_FN_STR_RIGHT = 0x00000200,
+        SQL_FN_STR_RTRIM = 0x00000400,
+        SQL_FN_STR_SUBSTRING = 0x00000800,
+        SQL_FN_STR_UCASE = 0x00001000,
+        SQL_FN_STR_ASCII = 0x00002000,
+        SQL_FN_STR_CHAR = 0x00004000,
         SQL_FN_STR_DIFFERENCE = 0x00008000,
-        SQL_FN_STR_LOCATE_2          = 0x00010000,
-        SQL_FN_STR_SOUNDEX          = 0x00020000,
-        SQL_FN_STR_SPACE          = 0x00040000,
-        SQL_FN_STR_BIT_LENGTH      = 0x00080000,
-        SQL_FN_STR_CHAR_LENGTH      = 0x00100000,
-        SQL_FN_STR_CHARACTER_LENGTH      = 0x00200000,
+        SQL_FN_STR_LOCATE_2 = 0x00010000,
+        SQL_FN_STR_SOUNDEX = 0x00020000,
+        SQL_FN_STR_SPACE = 0x00040000,
+        SQL_FN_STR_BIT_LENGTH = 0x00080000,
+        SQL_FN_STR_CHAR_LENGTH = 0x00100000,
+        SQL_FN_STR_CHARACTER_LENGTH = 0x00200000,
         SQL_FN_STR_OCTET_LENGTH = 0x00400000,
         SQL_FN_STR_POSITION = 0x00800000
     ],
-
-    SQL_FN_SYSTEM = 
-    [
-        //None = 0,
-
+    SQL_FN_SYSTEM = [
+        // None = 0,
         SQL_FN_SYS_USERNAME = 0x00000001,
         SQL_FN_SYS_DBNAME = 0x00000002,
         SQL_FN_SYS_IFNULL = 0x00000004
     ],
-
-    SQL_FN_TD = 
-    [
-        //None = 0,
-
-        SQL_FN_TD_NOW            = 0x00000001,
-        SQL_FN_TD_CURDATE            = 0x00000002,
-        SQL_FN_TD_DAYOFMONTH        = 0x00000004,
-        SQL_FN_TD_DAYOFWEEK            = 0x00000008,
-        SQL_FN_TD_DAYOFYEAR            = 0x00000010,
-        SQL_FN_TD_MONTH            = 0x00000020,
-        SQL_FN_TD_QUARTER            = 0x00000040,
-        SQL_FN_TD_WEEK            = 0x00000080,
-        SQL_FN_TD_YEAR            = 0x00000100,
-        SQL_FN_TD_CURTIME            = 0x00000200,
-        SQL_FN_TD_HOUR            = 0x00000400,
-        SQL_FN_TD_MINUTE            = 0x00000800,
-        SQL_FN_TD_SECOND            = 0x00001000,
-        SQL_FN_TD_TIMESTAMPADD        = 0x00002000,
-        SQL_FN_TD_TIMESTAMPDIFF        = 0x00004000,
-        SQL_FN_TD_DAYNAME          = 0x00008000,
-        SQL_FN_TD_MONTHNAME          = 0x00010000,
-        SQL_FN_TD_CURRENT_DATE      = 0x00020000,
-        SQL_FN_TD_CURRENT_TIME      = 0x00040000,
-        SQL_FN_TD_CURRENT_TIMESTAMP      = 0x00080000,
+    SQL_FN_TD = [
+        // None = 0,
+        SQL_FN_TD_NOW = 0x00000001,
+        SQL_FN_TD_CURDATE = 0x00000002,
+        SQL_FN_TD_DAYOFMONTH = 0x00000004,
+        SQL_FN_TD_DAYOFWEEK = 0x00000008,
+        SQL_FN_TD_DAYOFYEAR = 0x00000010,
+        SQL_FN_TD_MONTH = 0x00000020,
+        SQL_FN_TD_QUARTER = 0x00000040,
+        SQL_FN_TD_WEEK = 0x00000080,
+        SQL_FN_TD_YEAR = 0x00000100,
+        SQL_FN_TD_CURTIME = 0x00000200,
+        SQL_FN_TD_HOUR = 0x00000400,
+        SQL_FN_TD_MINUTE = 0x00000800,
+        SQL_FN_TD_SECOND = 0x00001000,
+        SQL_FN_TD_TIMESTAMPADD = 0x00002000,
+        SQL_FN_TD_TIMESTAMPDIFF = 0x00004000,
+        SQL_FN_TD_DAYNAME = 0x00008000,
+        SQL_FN_TD_MONTHNAME = 0x00010000,
+        SQL_FN_TD_CURRENT_DATE = 0x00020000,
+        SQL_FN_TD_CURRENT_TIME = 0x00040000,
+        SQL_FN_TD_CURRENT_TIMESTAMP = 0x00080000,
         SQL_FN_TD_EXTRACT = 0x00100000
     ],
-
-    SQL_SDF = 
-    [
+    SQL_SDF = [
         SQL_SDF_CURRENT_DATE = 0x00000001,
         SQL_SDF_CURRENT_TIME = 0x00000002,
         SQL_SDF_CURRENT_TIMESTAMP = 0x00000004
     ],
-
-    SQL_TSI =
-    [
-        //None = 0,
-
+    SQL_TSI = [
+        // None = 0,
         SQL_TSI_FRAC_SECOND = 0x00000001,
         SQL_TSI_SECOND = 0x00000002,
         SQL_TSI_MINUTE = 0x00000004,
@@ -1035,91 +956,76 @@ SQL_CVT =
         SQL_TSI_QUARTER = 0x00000080,
         SQL_TSI_YEAR = 0x00000100
     ],
-
-    SQL_AF = 
-    [
-        //None = 0,
-
-        SQL_AF_AVG        = 0x00000001,
-        SQL_AF_COUNT    = 0x00000002,
-        SQL_AF_MAX        = 0x00000004,
-        SQL_AF_MIN        = 0x00000008,
-        SQL_AF_SUM        = 0x00000010,
-        SQL_AF_DISTINCT    = 0x00000020,
-        SQL_AF_ALL        = 0x00000040,
-
+    SQL_AF = [
+        // None = 0,
+        SQL_AF_AVG = 0x00000001,
+        SQL_AF_COUNT = 0x00000002,
+        SQL_AF_MAX = 0x00000004,
+        SQL_AF_MIN = 0x00000008,
+        SQL_AF_SUM = 0x00000010,
+        SQL_AF_DISTINCT = 0x00000020,
+        SQL_AF_ALL = 0x00000040,
         All = 0xFF
     ],
-
-    SQL_SC = 
-    [
-        //None = 0,
-
-        SQL_SC_SQL92_ENTRY            = 0x00000001,
-        SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
-        SQL_SC_SQL92_INTERMEDIATE        = 0x00000004,
-        SQL_SC_SQL92_FULL            = 0x00000008
+    SQL_SC = [
+        // None = 0,
+        SQL_SC_SQL92_ENTRY = 0x00000001,
+        SQL_SC_FIPS127_2_TRANSITIONAL = 0x00000002,
+        SQL_SC_SQL92_INTERMEDIATE = 0x00000004,
+        SQL_SC_SQL92_FULL = 0x00000008
     ],
-
-    SQL_DL_SQL92 = 
-    [
-        SQL_DL_SQL92_DATE                    = 0x00000001,
-        SQL_DL_SQL92_TIME                    = 0x00000002,
-        SQL_DL_SQL92_TIMESTAMP                = 0x00000004,
-        SQL_DL_SQL92_INTERVAL_YEAR                = 0x00000008,
-        SQL_DL_SQL92_INTERVAL_MONTH                = 0x00000010,
-        SQL_DL_SQL92_INTERVAL_DAY                = 0x00000020,
-        SQL_DL_SQL92_INTERVAL_HOUR                = 0x00000040,
-        SQL_DL_SQL92_INTERVAL_MINUTE            = 0x00000080,
-        SQL_DL_SQL92_INTERVAL_SECOND            = 0x00000100,
-        SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH            = 0x00000200,
-        SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR            = 0x00000400,
-        SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE            = 0x00000800,
-        SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND            = 0x00001000,
-        SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE        = 0x00002000,
-        SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND        = 0x00004000,
-        SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND     = 0x00008000
+    SQL_DL_SQL92 = [
+        SQL_DL_SQL92_DATE = 0x00000001,
+        SQL_DL_SQL92_TIME = 0x00000002,
+        SQL_DL_SQL92_TIMESTAMP = 0x00000004,
+        SQL_DL_SQL92_INTERVAL_YEAR = 0x00000008,
+        SQL_DL_SQL92_INTERVAL_MONTH = 0x00000010,
+        SQL_DL_SQL92_INTERVAL_DAY = 0x00000020,
+        SQL_DL_SQL92_INTERVAL_HOUR = 0x00000040,
+        SQL_DL_SQL92_INTERVAL_MINUTE = 0x00000080,
+        SQL_DL_SQL92_INTERVAL_SECOND = 0x00000100,
+        SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH = 0x00000200,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR = 0x00000400,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE = 0x00000800,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND = 0x00001000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE = 0x00002000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND = 0x00004000,
+        SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND = 0x00008000
     ],
-
-    SQL_IK = 
-    [
-        SQL_IK_NONE        = 0x00000000,
-        SQL_IK_ASC        = 0x00000001,
-        SQL_IK_DESC        = 0x00000002,
-        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+    SQL_IK = [
+        SQL_IK_NONE = 0x00000000,
+        SQL_IK_ASC = 0x00000001,
+        SQL_IK_DESC = 0x00000002,
+        SQL_IK_ALL = 0x00000003
+        // SQL_IK_ASC | SQL_IK_DESC
     ],
-
-    SQL_ISV = 
-    [
-        SQL_ISV_ASSERTIONS            = 0x00000001,
-        SQL_ISV_CHARACTER_SETS        = 0x00000002,
-        SQL_ISV_CHECK_CONSTRAINTS        = 0x00000004,
-        SQL_ISV_COLLATIONS            = 0x00000008,
-        SQL_ISV_COLUMN_DOMAIN_USAGE        = 0x00000010,
-        SQL_ISV_COLUMN_PRIVILEGES        = 0x00000020,
-        SQL_ISV_COLUMNS            = 0x00000040,
-        SQL_ISV_CONSTRAINT_COLUMN_USAGE    = 0x00000080,
-        SQL_ISV_CONSTRAINT_TABLE_USAGE    = 0x00000100,
-        SQL_ISV_DOMAIN_CONSTRAINTS        = 0x00000200,
-        SQL_ISV_DOMAINS            = 0x00000400,
-        SQL_ISV_KEY_COLUMN_USAGE        = 0x00000800,
-        SQL_ISV_REFERENTIAL_CONSTRAINTS    = 0x00001000,
-        SQL_ISV_SCHEMATA            = 0x00002000,
-        SQL_ISV_SQL_LANGUAGES        = 0x00004000,
-        SQL_ISV_TABLE_CONSTRAINTS      = 0x00008000,
-        SQL_ISV_TABLE_PRIVILEGES      = 0x00010000,
-        SQL_ISV_TABLES          = 0x00020000,
-        SQL_ISV_TRANSLATIONS      = 0x00040000,
-        SQL_ISV_USAGE_PRIVILEGES      = 0x00080000,
-        SQL_ISV_VIEW_COLUMN_USAGE      = 0x00100000,
+    SQL_ISV = [
+        SQL_ISV_ASSERTIONS = 0x00000001,
+        SQL_ISV_CHARACTER_SETS = 0x00000002,
+        SQL_ISV_CHECK_CONSTRAINTS = 0x00000004,
+        SQL_ISV_COLLATIONS = 0x00000008,
+        SQL_ISV_COLUMN_DOMAIN_USAGE = 0x00000010,
+        SQL_ISV_COLUMN_PRIVILEGES = 0x00000020,
+        SQL_ISV_COLUMNS = 0x00000040,
+        SQL_ISV_CONSTRAINT_COLUMN_USAGE = 0x00000080,
+        SQL_ISV_CONSTRAINT_TABLE_USAGE = 0x00000100,
+        SQL_ISV_DOMAIN_CONSTRAINTS = 0x00000200,
+        SQL_ISV_DOMAINS = 0x00000400,
+        SQL_ISV_KEY_COLUMN_USAGE = 0x00000800,
+        SQL_ISV_REFERENTIAL_CONSTRAINTS = 0x00001000,
+        SQL_ISV_SCHEMATA = 0x00002000,
+        SQL_ISV_SQL_LANGUAGES = 0x00004000,
+        SQL_ISV_TABLE_CONSTRAINTS = 0x00008000,
+        SQL_ISV_TABLE_PRIVILEGES = 0x00010000,
+        SQL_ISV_TABLES = 0x00020000,
+        SQL_ISV_TRANSLATIONS = 0x00040000,
+        SQL_ISV_USAGE_PRIVILEGES = 0x00080000,
+        SQL_ISV_VIEW_COLUMN_USAGE = 0x00100000,
         SQL_ISV_VIEW_TABLE_USAGE = 0x00200000,
-        SQL_ISV_VIEWS          = 0x00400000
+        SQL_ISV_VIEWS = 0x00400000
     ],
-
-    SQL_SRJO = 
-    [
-        //None = 0,
-
+    SQL_SRJO = [
+        // None = 0,
         SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
         SQL_SRJO_CROSS_JOIN = 0x00000002,
         SQL_SRJO_EXCEPT_JOIN = 0x00000004,
@@ -1131,27 +1037,22 @@ SQL_CVT =
         SQL_SRJO_RIGHT_OUTER_JOIN = 0x00000100,
         SQL_SRJO_UNION_JOIN = 0x00000200
     ],
-
-    SQL_SRVC = 
-    [
+    SQL_SRVC = [
         SQL_SRVC_VALUE_EXPRESSION = 0x00000001,
         SQL_SRVC_NULL = 0x00000002,
         SQL_SRVC_DEFAULT = 0x00000004,
         SQL_SRVC_ROW_SUBQUERY = 0x00000008
     ],
-
-    //public static readonly int SQL_OV_ODBC3 = 3;
-    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
-
-    //Pooling
-    SQL_CP = 
-    [
+    // public static readonly int SQL_OV_ODBC3 = 3;
+    // public const Int32 SQL_NTS = -3;
+    // flags for null-terminated string
+    // Pooling
+    SQL_CP = [
         OFF = 0,
         ONE_PER_DRIVER = 1,
         ONE_PER_HENV = 2
     ],
-
-/*
+    /*
     public const Int32 SQL_CD_TRUE = 1;
     public const Int32 SQL_CD_FALSE = 0;
 
@@ -1159,32 +1060,28 @@ SQL_CVT =
     public const Int32 SQL_IS_POINTER = -4;
     public const Int32 SQL_IS_PTR = 1;
 */
-    SQL_DRIVER =
-    [
+    SQL_DRIVER = [
         NOPROMPT = 0,
         COMPLETE = 1,
         PROMPT = 2,
         COMPLETE_REQUIRED = 3
     ],
-
     // Column set for SQLPrimaryKeys
-    SQL_PRIMARYKEYS =
-    [
+    SQL_PRIMARYKEYS = [
         /*
                     CATALOGNAME         = 1,                    // TABLE_CAT
                     SCHEMANAME          = 2,                    // TABLE_SCHEM
                     TABLENAME           = 3,                    // TABLE_NAME
         */
-        COLUMNNAME = 4                    // COLUMN_NAME
+        COLUMNNAME = 4
+        // COLUMN_NAME
         /*
                     KEY_SEQ             = 5,                    // KEY_SEQ
                     PKNAME              = 6,                    // PK_NAME
         */
     ],
-
     // Column set for SQLStatistics
-    SQL_STATISTICS =
-    [
+    SQL_STATISTICS = [
         /*
                     CATALOGNAME         = 1,                    // TABLE_CAT
                     SCHEMANAME          = 2,                    // TABLE_SCHEM
@@ -1192,12 +1089,15 @@ SQL_CVT =
                     NONUNIQUE           = 4,                    // NON_UNIQUE
                     INDEXQUALIFIER      = 5,                    // INDEX_QUALIFIER
         */
-        INDEXNAME = 6,                    // INDEX_NAME
+        INDEXNAME = 6,
+        // INDEX_NAME
         /*
                     TYPE                = 7,                    // TYPE
         */
-        ORDINAL_POSITION = 8,                    // ORDINAL_POSITION
-        COLUMN_NAME = 9                    // COLUMN_NAME
+        ORDINAL_POSITION = 8,
+        // ORDINAL_POSITION
+        COLUMN_NAME = 9
+        // COLUMN_NAME
         /*
                     ASC_OR_DESC         = 10,                   // ASC_OR_DESC
                     CARDINALITY         = 11,                   // CARDINALITY
@@ -1205,14 +1105,13 @@ SQL_CVT =
                     FILTER_CONDITION    = 13,                   // FILTER_CONDITION
         */
     ],
-
     // Column set for SQLSpecialColumns
-    SQL_SPECIALCOLUMNSET =
-    [
+    SQL_SPECIALCOLUMNSET = [
         /*
                     SCOPE               = 1,                    // SCOPE
         */
-        COLUMN_NAME = 2                    // COLUMN_NAME
+        COLUMN_NAME = 2
+        // COLUMN_NAME
         /*
                     DATA_TYPE           = 3,                    // DATA_TYPE
                     TYPE_NAME           = 4,                    // TYPE_NAME
@@ -1222,10 +1121,8 @@ SQL_CVT =
                     PSEUDO_COLUMN       = 8,                    // PSEUDO_COLUMN
         */
     ],
-
-    SQL_DIAG =
-    [
-        CURSOR_ROW_COUNT= -1249,
+    SQL_DIAG = [
+        CURSOR_ROW_COUNT = -1249,
         ROW_NUMBER = -1248,
         COLUMN_NUMBER = -1247,
         RETURNCODE = 1,
@@ -1241,13 +1138,11 @@ SQL_CVT =
         SERVER_NAME = 11,
         DYNAMIC_FUNCTION_CODE = 12
     ],
-
-    SQL_SU =
-    [
-        SQL_SU_DML_STATEMENTS       = 0x00000001,
+    SQL_SU = [
+        SQL_SU_DML_STATEMENTS = 0x00000001,
         SQL_SU_PROCEDURE_INVOCATION = 0x00000002,
-        SQL_SU_TABLE_DEFINITION     = 0x00000004,
-        SQL_SU_INDEX_DEFINITION     = 0x00000008,
+        SQL_SU_TABLE_DEFINITION = 0x00000004,
+        SQL_SU_INDEX_DEFINITION = 0x00000008,
         SQL_SU_PRIVILEGE_DEFINITION = 0x00000010
     ]
 ]

--- a/samples/TripPin/1-OData/TripPin.pq
+++ b/samples/TripPin/1-OData/TripPin.pq
@@ -1,13 +1,9 @@
 ﻿section TripPin;
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Feed = Value.ReplaceType(TripPinImpl, type function (url as Uri.Type) as any);
 
-TripPinImpl = (url as text) =>
-    let
-        source = OData.Feed(url)
-    in
-        source;
+TripPinImpl = (url as text) => let source = OData.Feed(url) in source;
 
 // Data Source Kind description
 TripPin = [
@@ -25,6 +21,5 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin OData", "TripPin OData" }
+    ButtonText = {"TripPin OData", "TripPin OData"}
 ];
-

--- a/samples/TripPin/1-OData/TripPin.query.pq
+++ b/samples/TripPin/1-OData/TripPin.query.pq
@@ -1,5 +1,2 @@
 ﻿// Use this file to write queries to test your data connector
-let
-    result = TripPin.Feed("http://services.odata.org/v4/TripPinService/")
-in
-    result
+let result = TripPin.Feed("http://services.odata.org/v4/TripPinService/") in result

--- a/samples/TripPin/10-TableView1/Diagnostics.pqm
+++ b/samples/TripPin/10-TableView1/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/TripPin/10-TableView1/Table.ChangeType.pqm
+++ b/samples/TripPin/10-TableView1/Table.ChangeType.pqm
@@ -2,79 +2,114 @@
     // table should be an actual Table.Type, or a List.Type of Records
     Table.ChangeType = (table, tableType as type) as nullable table =>
         // we only operate on table types
-        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        if (not Type.Is(tableType, type table)) then
+            error "type argument should be a table type"
+        else
         // if we have a null value, just return it
-        if (table = null) then table else
-        let
-            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
-            columnsAsTable = Record.ToTable(columnsForType),
-            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
-            previousMeta = Value.Metadata(tableType),
-
-            // make sure we have a table
-            parameterType = Value.Type(table),
-            _table =
-                if (Type.Is(parameterType, type table)) then table
-                else if (Type.Is(parameterType, type list)) then
-                    let
-                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
-                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
-                        result =
-                            // if the member is a record (as expected), then expand it. 
+        if (table = null) then
+            table
+        else
+            let
+                columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+                columnsAsTable = Record.ToTable(columnsForType),
+                schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+                previousMeta = Value.Metadata(tableType),
+                // make sure we have a table
+                parameterType = Value.Type(table),
+                _table =
+                    if (Type.Is(parameterType, type table)) then
+                        table
+                    else if (Type.Is(parameterType, type list)) then
+                        let
+                            asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                            firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                            result =
+                            // if the member is a record (as expected), then expand it.
                             if (Type.Is(firstValueType, type record)) then
                                 Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
                             else
-                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
-                    in
-                        if (List.IsEmpty(table)) then
-                            #table({"a"}, {})
-                        else result
+                                error
+                                    Error.Record(
+                                        "Error.Parameter",
+                                        "table argument is a list, but not a list of records",
+                                        [
+                                            ValueType = firstValueType
+                                        ]
+                                    )
+                        in
+                            if (List.IsEmpty(table)) then
+                                #table({"a"}, {})
+                            else
+                                result
+                    else
+                        error
+                            Error.Record(
+                                "Error.Parameter",
+                                "table argument should be a table or list of records",
+                                [
+                                    ValueType = parameterType
+                                ]
+                            ),
+                reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+                // process primitive values - this will call Table.TransformColumnTypes
+                map = (t) =>
+                    if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any
+                    then
+                        null
+                    else
+                        t,
+                mapped = Table.TransformColumns(schema, {"Type", map}),
+                omitted = Table.SelectRows(mapped, each [Type] <> null),
+                existingColumns = Table.ColumnNames(reordered),
+                removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+                primitiveTransforms = Table.ToRows(removeMissing),
+                changedPrimitives = Table.TransformColumnTypes(reordered, primitiveTransforms),
+                // Get the list of transforms we'll use for Record types
+                recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+                recordTypeTransformations = Table.AddColumn(
+                    recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function
+                ),
+                recordChanges = Table.ToRows(
+                    Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})
+                ),
+                // Get the list of transforms we'll use for List types
+                listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+                listTransforms = Table.AddColumn(
+                    listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type
+                ),
+                listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+                // Get the list of transforms we'll use for Table types
+                tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+                tableTransforms = Table.AddColumn(
+                    tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type
+                ),
+                tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+                // Perform all of our transformations
+                allColumnTransforms = recordChanges & listChanges & tableChanges,
+                changedRecordTypes =
+                    if (List.IsEmpty(allColumnTransforms)) then
+                        changedPrimitives
+                    else
+                        Table.TransformColumns(changedPrimitives, allColumnTransforms, null, MissingField.Ignore),
+                // set final type
+                withType = Value.ReplaceType(changedRecordTypes, tableType)
+            in
+                if (List.IsEmpty(Record.FieldNames(columnsForType))) then
+                    table
                 else
-                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
-
-            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
-
-            // process primitive values - this will call Table.TransformColumnTypes
-            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
-            mapped = Table.TransformColumns(schema, {"Type", map}),
-            omitted = Table.SelectRows(mapped, each [Type] <> null),
-            existingColumns = Table.ColumnNames(reordered),
-            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
-            primitiveTransforms = Table.ToRows(removeMissing),
-            changedPrimitives = Table.TransformColumnTypes(reordered, primitiveTransforms),
-        
-            // Get the list of transforms we'll use for Record types
-            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
-            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
-            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
-
-            // Get the list of transforms we'll use for List types
-            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
-            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
-            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
-
-            // Get the list of transforms we'll use for Table types
-            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
-            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
-            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
-
-            // Perform all of our transformations
-            allColumnTransforms = recordChanges & listChanges & tableChanges,
-            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimitives else Table.TransformColumns(changedPrimitives, allColumnTransforms, null, MissingField.Ignore),
-
-            // set final type
-            withType = Value.ReplaceType(changedRecordTypes, tableType)
-        in
-            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
-
+                    withType meta previousMeta,
     // If given a generic record type (no predefined fields), the original record is returned
     Record.ChangeType = (record as record, recordType as type) =>
         let
             // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
-            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fields =
+                try
+                    Type.RecordFields(recordType)
+                otherwise
+                    error "Record.ChangeType: failed to get record fields. Is this a record type?",
             fieldNames = Record.FieldNames(fields),
             fieldTable = Record.ToTable(fields),
-            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            optionalFields = Table.SelectRows(fieldTable, each[Value][Optional])[Name],
             requiredFields = List.Difference(fieldNames, optionalFields),
             // make sure all required fields exist
             withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
@@ -86,54 +121,75 @@
             // order the same as the record type
             reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
         in
-            if (List.IsEmpty(fieldNames)) then record else reorder,
-
+            if (List.IsEmpty(fieldNames)) then
+                record
+            else
+                reorder,
     List.ChangeType = (list as list, listType as type) =>
-        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
-        let
-            listItemType = Type.ListItem(listType),
-            transform = GetTransformByType(listItemType),
-            modifiedValues = List.Transform(list, transform),
-            typed = Value.ReplaceType(modifiedValues, listType)
-        in
-            typed,
-
+        if (not Type.Is(listType, type list)) then
+            error "type argument should be a list type"
+        else
+            let
+                listItemType = Type.ListItem(listType),
+                transform = GetTransformByType(listItemType),
+                modifiedValues = List.Transform(list, transform),
+                typed = Value.ReplaceType(modifiedValues, listType)
+            in
+                typed,
     // Returns a table type for the provided schema table
     Schema.ToTableType = (schema as table) as type =>
         let
-            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toList = List.Transform(schema[Type], (t) => [Type = t, Optional = false]),
             toRecord = Record.FromList(toList, schema[Name]),
             toType = Type.ForRecord(toRecord, false),
             previousMeta = Value.Metadata(schema)
         in
             type table (toType) meta previousMeta,
-
     // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
     // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
     GetTransformsForType = (_type as type) as list =>
         let
-            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
-                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
-                            else error "GetTransformsForType: record or table type expected",
+            fieldsOrColumns =
+                if (Type.Is(_type, type record)) then
+                    Type.RecordFields(_type)
+                else if (Type.Is(_type, type table)) then
+                    Type.RecordFields(Type.TableRow(_type))
+                else
+                    error "GetTransformsForType: record or table type expected",
             toTable = Record.ToTable(fieldsOrColumns),
-            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformColumn = Table.AddColumn(
+                toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type
+            ),
             transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
         in
             transformMap,
-
     GetTransformByType = (type_in as type) as function =>
-        let _type = Type.NonNullable(type_in) in
-        if (Type.Is(_type, type number)) then Number.From
-        else if (Type.Is(_type, type text)) then Text.From
-        else if (Type.Is(_type, type date)) then Date.From
-        else if (Type.Is(_type, type datetime)) then DateTime.From
-        else if (Type.Is(_type, type duration)) then Duration.From
-        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
-        else if (Type.Is(_type, type logical)) then Logical.From
-        else if (Type.Is(_type, type time)) then Time.From
-        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
-        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
-        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
-        else (t) => t
+        let
+            _type = Type.NonNullable(type_in)
+        in
+            if (Type.Is(_type, type number)) then
+                Number.From
+            else if (Type.Is(_type, type text)) then
+                Text.From
+            else if (Type.Is(_type, type date)) then
+                Date.From
+            else if (Type.Is(_type, type datetime)) then
+                DateTime.From
+            else if (Type.Is(_type, type duration)) then
+                Duration.From
+            else if (Type.Is(_type, type datetimezone)) then
+                DateTimeZone.From
+            else if (Type.Is(_type, type logical)) then
+                Logical.From
+            else if (Type.Is(_type, type time)) then
+                Time.From
+            else if (Type.Is(_type, type record)) then
+                (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+            else if (Type.Is(_type, type table)) then
+                (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+            else if (Type.Is(_type, type list)) then
+                (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+            else
+                (t) => t
 in
     Table.ChangeType

--- a/samples/TripPin/10-TableView1/Table.GenerateByPage.pqm
+++ b/samples/TripPin/10-TableView1/Table.GenerateByPage.pqm
@@ -1,21 +1,24 @@
 ﻿(getNextPage as function) as table =>
-    let        
+    let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+            // get the first page of data
+            () => getNextPage(null),
+            // stop when the function returns null
+            (lastPage) => lastPage <> null,
+            // pass the previous page to the next function call
+            (lastPage) => getNextPage(lastPage)
         ),
         // concatenate the pages together
         tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = tableOfPages{0} ?
     in
         // if we didn't get back any pages of data, return an empty table
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-		// check for empty first table
-		else if (Table.IsEmpty(firstRow[Column1])) then
-			firstRow[Column1]
+            // check for empty first table
+        else if (Table.IsEmpty(firstRow[Column1])) then
+            firstRow[Column1]
         else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),

--- a/samples/TripPin/10-TableView1/Table.ToNavigationTable.pqm
+++ b/samples/TripPin/10-TableView1/Table.ToNavigationTable.pqm
@@ -9,12 +9,11 @@
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)

--- a/samples/TripPin/10-TableView1/TripPin.pq
+++ b/samples/TripPin/10-TableView1/TripPin.pq
@@ -3,7 +3,7 @@
 // Data Source Kind description
 TripPin = [
     // TestConnection is required to enable the connector through the Gateway
-    TestConnection = (dataSourcePath) => { "TripPin.Contents" },
+    TestConnection = (dataSourcePath) => {"TripPin.Contents"},
     Authentication = [
         Anonymous = []
     ],
@@ -14,28 +14,25 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin QueryFolding 1", "TripPin QueryFolding 1" }
+    ButtonText = {"TripPin QueryFolding 1", "TripPin QueryFolding 1"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
 // Define our top level table types
-AirlinesType = type table [ AirlineCode = text, Name = text ];
+AirlinesType = type table [AirlineCode = text, Name = text];
 
-AirportsType = type table [
-    Name = text,
-    IataCode = text,
-    Location = LocationType
-];
+AirportsType = type table [Name = text, IataCode = text, Location = LocationType];
 
 PeopleType = type table [
     UserName = text,
@@ -48,46 +45,28 @@ PeopleType = type table [
 ];
 
 // remaining structured types
-LocationType = type [
-    Address = text,
-    City = CityType,
-    Loc = LocType
-];
+LocationType = type [Address = text, City = CityType, Loc = LocType];
 
-CityType = type [
-    CountryRegion = text,
-    Name = text,
-    Region = text
-];
+CityType = type [CountryRegion = text, Name = text, Region = text];
 
-LocType = type [
-    #"type" = text,
-    coordinates = {number},
-    crs = CrsType
-];
+LocType = type [#"type" = text, coordinates = {number}, crs = CrsType];
 
-CrsType = type [
-    #"type" = text,
-    properties = record
-];
+CrsType = type [#"type" = text, properties = record];
 
-SchemaTable = #table({"Entity", "Type"}, {
-    {"Airlines", AirlinesType },    
-    {"Airports", AirportsType },
-    {"People", PeopleType}    
-});
-        
+SchemaTable = #table(
+    {"Entity", "Type"}, {{"Airlines", AirlinesType}, {"Airports", AirportsType}, {"People", PeopleType}}
+);
+
 GetSchemaForEntity = (entity as text) as type =>
-    try 
-        SchemaTable{[Entity=entity]}[Type]
+    try
+        SchemaTable{[Entity = entity]}[Type]
     otherwise
         let
             message = Text.Format("Couldn't find entity: '#{0}'", {entity})
         in
             Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
 
-
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -114,162 +93,148 @@ TripPin.View = (baseUrl as text, entity as text) as table =>
         // We wrap the record with Diagnostics.WrapHandlers() to get some automatic
         // tracing if a handler returns an error.
         //
-        View = (state as record) => Table.View(null, Diagnostics.WrapHandlers([
-
-            // Returns the table type returned by GetRows()
-            GetType = () => CalculateSchema(state),
-
-            // Called last - retrieves the data from the calculated URL
-            GetRows = () => 
-                let
-                    finalSchema = CalculateSchema(state),
-                    finalUrl = CalculateUrl(state),
-                    result = TripPin.Feed(finalUrl, finalSchema),
-                    appliedType = Table.ChangeType(result, finalSchema)
-                in
-                    appliedType,
-
-            // GetRowCount - called when all we want is the total row count.
-            // Most OData services support $count, but it only works if
-            // no other query parameters are sent (i.e. $top, or $filter).
-            // Our implementation will first check for other query state -
-            // if there are any state fields set by other handlers, we
-            // return "..." unimplemented, because we won't be able to fold
-            // the request to the server.
-            GetRowCount = () as number =>
-                if (Record.FieldCount(Record.RemoveFields(state, {"Url", "Entity", "Schema"}, MissingField.Ignore)) > 0) then
-                    ...
-                else
-                    let
-                        newState = state & [ RowCountOnly = true ],
-                        finalUrl = CalculateUrl(newState),
-                        value = TripPin.Scalar(finalUrl),
-                        converted = Number.FromText(value)
-                    in
-                        converted,
-
-            // OnTake - handles the Table.FirstN transform, limiting
-            // the maximum number of rows returned in the result set.
-            // The count value should be >= 0.
-            OnTake = (count as number) =>
-                let
-                    newState = state & [ Top = count ]
-                in
-                    @View(newState),
-
-            // OnSkip - handles the Table.Skip transform.
-            // The count value should be >= 0.
-            OnSkip = (count as number) =>
-                let
-                    newState = state & [ Skip = count ]
-                in
-                    @View(newState),
-
-            // OnSelectColumns - handles column selection
-            OnSelectColumns = (columns as list) =>
-                let
-                    // get the current schema
-                    currentSchema = CalculateSchema(state),
-                    // get the columns from the current schema (which is an M Type value)
-                    rowRecordType = Type.RecordFields(Type.TableRow(currentSchema)),
-                    existingColumns = Record.FieldNames(rowRecordType),
-                    // calculate the new schema
-                    columnsToRemove = List.Difference(existingColumns, columns),
-                    updatedColumns = Record.RemoveFields(rowRecordType, columnsToRemove),
-                    newSchema = type table (Type.ForRecord(updatedColumns, false))
-                in
-                    @View(state & 
-                        [ 
-                            SelectColumns = columns,
-                            Schema = newSchema
-                        ]
-                    ),
-
-            // OnSort - receives a list of records containing two fields: 
-            //    [Name]  - the name of the column to sort on
-            //    [Order] - equal to Order.Ascending or Order.Descending
-            // If there are multiple records, the sort order must be maintained.
-            //
-            // OData allows you to sort on columns that do not appear in the result
-            // set, so we do not have to validate that the sorted columns are in our 
-            // existing schema.
-            OnSort = (order as list) =>
-                let
-                    // This will convert the list of records to a list of text,
-                    // where each entry is "<columnName> <asc|desc>"
-                    sorting = List.Transform(order, (o) => 
-                        let
-                            column = o[Name],
-                            order = o[Order],
-                            orderText = if (order = Order.Ascending) then "asc" else "desc"
-                        in
-                            column & " " & orderText
-                    ),
-                    orderBy = Text.Combine(sorting, ", ")
-                in
-                    @View(state & [ OrderBy = orderBy ]),
-
-            //
-            // Helper functions
-            //
-            // Retrieves the cached schema. If this is the first call
-            // to CalculateSchema, the table type is calculated based on
-            // entity name that was passed into the function.
-            CalculateSchema = (state) as type =>
-                if (state[Schema]? = null) then
-                    GetSchemaForEntity(entity)
-                else
-                    state[Schema],
-
-            // Calculates the final URL based on the current state.
-            CalculateUrl = (state) as text => 
-                let
-                    urlWithEntity = Uri.Combine(state[Url], state[Entity]),
-
-                    // Check for $count. If all we want is a row count,
-                    // then we add /$count to the path value (following the entity name).
-                    urlWithRowCount =
-                        if (state[RowCountOnly]? = true) then
-                            urlWithEntity & "/$count"
-                        else
-                            urlWithEntity,
-
-                    // Uri.BuildQueryString requires that all field values
-                    // are text literals.
-                    defaultQueryString = [],
-
-                    // Check for Top defined in our state
-                    qsWithTop =
-                        if (state[Top]? <> null) then
-                            defaultQueryString & [ #"$top" = Number.ToText(state[Top]) ]
-                        else
-                            defaultQueryString,
-
-                    // Check for Skip defined in our state
-                    qsWithSkip = 
-                        if (state[Skip]? <> null) then
-                            qsWithTop & [ #"$skip" = Number.ToText(state[Skip]) ]
-                        else
-                            qsWithTop,
-
-                    // Check for explicitly selected columns
-                    qsWithSelect =
-                        if (state[SelectColumns]? <> null) then
-                            qsWithSkip & [ #"$select" = Text.Combine(state[SelectColumns], ",") ]
-                        else
-                            qsWithSkip,
-
-                    qsWithOrderBy = 
-                        if (state[OrderBy]? <> null) then
-                            qsWithSelect & [ #"$orderby" = state[OrderBy] ]
-                        else
-                            qsWithSelect,
-
-                    encodedQueryString = Uri.BuildQueryString(qsWithOrderBy),
-                    finalUrl = urlWithRowCount & "?" & encodedQueryString
-                in
-                    finalUrl
-        ]))
+        View = (state as record) =>
+            Table.View(
+                null,
+                Diagnostics.WrapHandlers(
+                    [
+                        // Returns the table type returned by GetRows()
+                        GetType = () => CalculateSchema(state),
+                        // Called last - retrieves the data from the calculated URL
+                        GetRows = () =>
+                            let
+                                finalSchema = CalculateSchema(state),
+                                finalUrl = CalculateUrl(state),
+                                result = TripPin.Feed(finalUrl, finalSchema),
+                                appliedType = Table.ChangeType(result, finalSchema)
+                            in
+                                appliedType,
+                        // GetRowCount - called when all we want is the total row count.
+                        // Most OData services support $count, but it only works if
+                        // no other query parameters are sent (i.e. $top, or $filter).
+                        // Our implementation will first check for other query state -
+                        // if there are any state fields set by other handlers, we
+                        // return "..." unimplemented, because we won't be able to fold
+                        // the request to the server.
+                        GetRowCount = () as number =>
+                            if (
+                                Record.FieldCount(
+                                    Record.RemoveFields(state, {"Url", "Entity", "Schema"}, MissingField.Ignore)
+                                ) > 0
+                            ) then
+                                ...
+                            else
+                                let
+                                    newState = state & [RowCountOnly = true],
+                                    finalUrl = CalculateUrl(newState),
+                                    value = TripPin.Scalar(finalUrl),
+                                    converted = Number.FromText(value)
+                                in
+                                    converted,
+                        // OnTake - handles the Table.FirstN transform, limiting
+                        // the maximum number of rows returned in the result set.
+                        // The count value should be >= 0.
+                        OnTake = (count as number) => let newState = state & [Top = count] in @View(newState),
+                        // OnSkip - handles the Table.Skip transform.
+                        // The count value should be >= 0.
+                        OnSkip = (count as number) => let newState = state & [Skip = count] in @View(newState),
+                        // OnSelectColumns - handles column selection
+                        OnSelectColumns = (columns as list) =>
+                            let
+                                // get the current schema
+                                currentSchema = CalculateSchema(state),
+                                // get the columns from the current schema (which is an M Type value)
+                                rowRecordType = Type.RecordFields(Type.TableRow(currentSchema)),
+                                existingColumns = Record.FieldNames(rowRecordType),
+                                // calculate the new schema
+                                columnsToRemove = List.Difference(existingColumns, columns),
+                                updatedColumns = Record.RemoveFields(rowRecordType, columnsToRemove),
+                                newSchema = type table (Type.ForRecord(updatedColumns, false))
+                            in
+                                @View(state & [
+                                    SelectColumns = columns,
+                                    Schema = newSchema
+                                ]),
+                        // OnSort - receives a list of records containing two fields:
+                        //    [Name]  - the name of the column to sort on
+                        //    [Order] - equal to Order.Ascending or Order.Descending
+                        // If there are multiple records, the sort order must be maintained.
+                        //
+                        // OData allows you to sort on columns that do not appear in the result
+                        // set, so we do not have to validate that the sorted columns are in our
+                        // existing schema.
+                        OnSort = (order as list) =>
+                            let
+                                // This will convert the list of records to a list of text,
+                                // where each entry is "<columnName> <asc|desc>"
+                                sorting = List.Transform(
+                                    order,
+                                    (o) =>
+                                        let
+                                            column = o[Name],
+                                            order = o[Order],
+                                            orderText = if (order = Order.Ascending) then "asc" else "desc"
+                                        in
+                                            column & " " & orderText
+                                ),
+                                orderBy = Text.Combine(sorting, ", ")
+                            in
+                                @View(state & [OrderBy = orderBy]),
+                        //
+                        // Helper functions
+                        //
+                        // Retrieves the cached schema. If this is the first call
+                        // to CalculateSchema, the table type is calculated based on
+                        // entity name that was passed into the function.
+                        CalculateSchema = (state) as type =>
+                            if (state[Schema]? = null) then
+                                GetSchemaForEntity(entity)
+                            else
+                                state[Schema],
+                        // Calculates the final URL based on the current state.
+                        CalculateUrl = (state) as text =>
+                            let
+                                urlWithEntity = Uri.Combine(state[Url], state[Entity]),
+                                // Check for $count. If all we want is a row count,
+                                // then we add /$count to the path value (following the entity name).
+                                urlWithRowCount =
+                                    if (state[RowCountOnly]? = true) then
+                                        urlWithEntity & "/$count"
+                                    else
+                                        urlWithEntity,
+                                // Uri.BuildQueryString requires that all field values
+                                // are text literals.
+                                defaultQueryString = [],
+                                // Check for Top defined in our state
+                                qsWithTop =
+                                    if (state[Top]? <> null) then
+                                        defaultQueryString & [#"$top" = Number.ToText(state[Top])]
+                                    else
+                                        defaultQueryString,
+                                // Check for Skip defined in our state
+                                qsWithSkip =
+                                    if (state[Skip]? <> null) then
+                                        qsWithTop & [#"$skip" = Number.ToText(state[Skip])]
+                                    else
+                                        qsWithTop,
+                                // Check for explicitly selected columns
+                                qsWithSelect =
+                                    if (state[SelectColumns]? <> null) then
+                                        qsWithSkip & [#"$select" = Text.Combine(state[SelectColumns], ",")]
+                                    else
+                                        qsWithSkip,
+                                qsWithOrderBy =
+                                    if (state[OrderBy]? <> null) then
+                                        qsWithSelect & [#"$orderby" = state[OrderBy]]
+                                    else
+                                        qsWithSelect,
+                                encodedQueryString = Uri.BuildQueryString(qsWithOrderBy),
+                                finalUrl = urlWithRowCount & "?" & encodedQueryString
+                            in
+                                finalUrl
+                    ]
+                )
+            )
     in
         View([Url = baseUrl, Entity = entity]);
 
@@ -278,12 +243,10 @@ TripPin.View = (baseUrl as text, entity as text) as table =>
 TripPin.Scalar = (url as text) as text =>
     let
         _url = Diagnostics.LogValue("TripPin.Scalar url", url),
-
         headers = DefaultRequestHeaders & [
             #"Accept" = "text/plain"
         ],
-
-        response = Web.Contents(_url, [ Headers = headers ]),
+        response = Web.Contents(_url, [Headers = headers]),
         toText = Text.FromBinary(response)
     in
         toText;
@@ -296,10 +259,10 @@ TripPin.Feed = (url as text, optional schema as type) as table =>
     in
         result;
 
-// 
+//
 // ** Replaced by TripPin.View **
 //
-// GetEntity = (url as text, entity as text) as table => 
+// GetEntity = (url as text, entity as text) as table =>
 //     let
 //         fullUrl = Uri.Combine(url, entity),
 //         schema = GetSchemaForEntity(entity),
@@ -307,27 +270,24 @@ TripPin.Feed = (url as text, optional schema as type) as table =>
 //         appliedSchema = Table.ChangeType(result, schema)
 //     in
 //         appliedSchema;
-// 
+//
 // TripPin.SuperSimpleView = (url as text, entity as text) as table =>
 //     Table.View(null, [
 //         GetType = () => Value.Type(GetRows()),
 //         GetRows = () => GetEntity(url, entity)
 //     ]);
-
 GetPage = (url as text, optional schema as type) as table =>
     let
-        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        response = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         body = Json.Document(response),
         nextLink = GetNextLink(body),
-        
         // If we have no schema, use Table.FromRecords() instead
         // (and hope that our results all have the same fields).
         // If we have a schema, expand the record using its field names
         data =
             if (schema = null) then
                 Diagnostics.LogFailure(
-                    "Error converting response body. Are the records uniform?",
-                    () => Table.FromRecords(body[value])
+                    "Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value])
                 )
             else
                 let
@@ -344,28 +304,28 @@ GetPage = (url as text, optional schema as type) as table =>
 // After every page, we check the "NextLink" record on the metadata of the previous request.
 // Table.GenerateByPage will keep asking for more pages until we return null.
 GetAllPagesByNextLink = (url as text, optional schema as type) as nullable table =>
-    Table.GenerateByPage((previous) => 
-        let
-            // if previous is null, then this is our first page of data
-            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
-            // if NextLink was set to null by the previous call, we know we have no more data
-            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
-        in
-            page
+    Table.GenerateByPage(
+        (previous) =>
+            let
+                // if previous is null, then this is our first page of data
+                nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+                // if NextLink was set to null by the previous call, we know we have no more data
+                page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+            in
+                page
     );
 
 // In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
 // We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
 GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
 
-// 
+//
 // Load common library functions
-// 
+//
 // TEMPORARY WORKAROUND until we're able to reference other M modules
 Extension.LoadFunction = (name as text) =>
     let
-        binary = Extension.Contents(name),
-        asText = Text.FromBinary(binary)
+        binary = Extension.Contents(name), asText = Text.FromBinary(binary)
     in
         Expression.Evaluate(asText, #shared);
 
@@ -375,6 +335,7 @@ Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");
 
 // Diagnostics module contains multiple functions. We can take the ones we need.
 Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+
 Diagnostics.LogValue = Diagnostics[LogValue];
 Diagnostics.LogFailure = Diagnostics[LogFailure];
 Diagnostics.WrapHandlers = Diagnostics[WrapHandlers];

--- a/samples/TripPin/10-TableView1/TripPin.query.pq
+++ b/samples/TripPin/10-TableView1/TripPin.query.pq
@@ -1,265 +1,326 @@
 ﻿section TripPinUnitTests;
 
-shared TripPin.UnitTest =
-[
+shared TripPin.UnitTest = [
     // Put any common variables here if you only want them to be evaluated once
     RootTable = TripPin.Contents(),
-    Airlines = RootTable{[Name="Airlines"]}[Data],
-    Airports = RootTable{[Name="Airports"]}[Data],
-    People = RootTable{[Name="People"]}[Data],
-
+    Airlines = RootTable{[Name = "Airlines"]}[Data],
+    Airports = RootTable{[Name = "Airports"]}[Data],
+    People = RootTable{[Name = "People"]}[Data],
     // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
     // <Expected Value> and <Actual Value> can be a literal or let statement
-    facts =
-    {
+    facts = {
         Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
         Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
         Fact("We have People data?", true, not Table.IsEmpty(People)),
-        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
-        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
-        Fact("Airline table has the right fields",
-            {"AirlineCode","Name"},
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),
+        Fact(
+            "Airline table has the right fields",
+            {"AirlineCode", "Name"},
             Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
         ),
         Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails]))),
-
         //
         // Query folding tests
         //
-
         // OnTake
-        Fact("Fold $top 1 on Airlines", 
-            #table( type table [AirlineCode = text, Name = text] , {{"AA", "American Airlines"}} ), 
+        Fact(
+            "Fold $top 1 on Airlines",
+            #table(type table [AirlineCode = text, Name = text], {{"AA", "American Airlines"}}),
             Table.FirstN(Airlines, 1)
         ),
-        Fact("Fold $top 0 on Airports", 
-            #table( type table [Name = text, IataCode = text, Location = record] , {} ), 
+        Fact(
+            "Fold $top 0 on Airports",
+            #table(type table [Name = text, IataCode = text, Location = record], {}),
             Table.FirstN(Airports, 0)
         ),
-
         // OnSkip
-        Fact("Fold $skip 14 on Airlines",
-            #table( type table [AirlineCode = text, Name = text] , {{"EK", "Emirates"}} ), 
+        Fact(
+            "Fold $skip 14 on Airlines",
+            #table(type table [AirlineCode = text, Name = text], {{"EK", "Emirates"}}),
             Table.Skip(Airlines, 14)
         ),
-        Fact("Fold $skip 0 and $top 1",
-            #table( type table [AirlineCode = text, Name = text] , {{"AA", "American Airlines"}} ),
+        Fact(
+            "Fold $skip 0 and $top 1",
+            #table(type table [AirlineCode = text, Name = text], {{"AA", "American Airlines"}}),
             Table.FirstN(Table.Skip(Airlines, 0), 1)
         ),
-
         // GetRowCount
         Fact("Fold $count", 15, Table.RowCount(Airlines)),
         // test will fail if "Fail on Folding Error" is set to false
         Fact("Fold $count + $top *error*", true, Test.IsFoldingError(try Table.RowCount(Table.FirstN(Airlines, 3)))),
-
         // OnSelectColumns
-        Fact("Fold $select single column", 
-            #table( type table [AirlineCode = text] , {{"AA"}} ),
+        Fact(
+            "Fold $select single column",
+            #table(type table [AirlineCode = text], {{"AA"}}),
             Table.FirstN(Table.SelectColumns(Airlines, {"AirlineCode"}), 1)
         ),
-        Fact("Fold $select multiple column", 
-             #table( type table [UserName = text, FirstName = text, LastName = text],{{"russellwhyte", "Russell", "Whyte"}}), 
+        Fact(
+            "Fold $select multiple column",
+            #table(
+                type table [UserName = text, FirstName = text, LastName = text], {
+                    {"russellwhyte", "Russell", "Whyte"}
+                }
+            ),
             Table.FirstN(Table.SelectColumns(People, {"UserName", "FirstName", "LastName"}), 1)
         ),
-        Fact("Fold $select with ignore column", 
-            #table( type table [AirlineCode = text] , {{"AA"}} ),
+        Fact(
+            "Fold $select with ignore column",
+            #table(type table [AirlineCode = text], {{"AA"}}),
             Table.FirstN(Table.SelectColumns(Airlines, {"AirlineCode", "DoesNotExist"}, MissingField.Ignore), 1)
         ),
-
         // OnSort
-        Fact("Fold $orderby single column",
-            #table( type table [AirlineCode = text, Name = text], {{"TK", "Turkish Airlines"}}),
+        Fact(
+            "Fold $orderby single column",
+            #table(type table [AirlineCode = text, Name = text], {{"TK", "Turkish Airlines"}}),
             Table.FirstN(Table.Sort(Airlines, {{"AirlineCode", Order.Descending}}), 1)
         ),
-        Fact("Fold $orderby multiple column",
-            #table( type table [UserName = text], {{"javieralfred"}}),
-            Table.SelectColumns(Table.FirstN(Table.Sort(People, {{"LastName", Order.Ascending}, {"UserName", Order.Descending}}), 1), {"UserName"})
+        Fact(
+            "Fold $orderby multiple column",
+            #table(type table [UserName = text], {{"javieralfred"}}),
+            Table.SelectColumns(
+                Table.FirstN(Table.Sort(People, {{"LastName", Order.Ascending}, {"UserName", Order.Descending}}), 1),
+                {"UserName"}
+            )
         )
     },
-
     report = Facts.Summarize(facts)
 ][report];
 
 // Returns true if there is a folding error, or the original record (for logging purposes) if not.
 Test.IsFoldingError = (tryResult as record) =>
-    if ( tryResult[HasError]? = true and tryResult[Error][Message] = "We couldn't fold the expression to the data source. Please try a simpler expression.") then
+    if (
+        tryResult[HasError]? = true
+        and tryResult[Error][Message] = "We couldn't fold the expression to the data source. Please try a simpler expression."
+    ) then
         true
     else
         tryResult;
 
-/// COMMON UNIT TESTING CODE 
+/// COMMON UNIT TESTING CODE
 Fact = (_subject as text, _expected, _actual) as record =>
-[   expected = try _expected,
-    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
-    actual = try _actual,
-    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
-    attempt = try safeExpected = safeActual,
-    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
-    resultOp = if result = "Success ✓" then " = " else " <> ",
-    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
-    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
-    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
-    fact =
-    [   Result = result &" "& addendumEvalAttempt,
-        Notes =_subject,
-        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
-    ]
-][fact];
+    [
+        expected = try _expected,
+        safeExpected = if expected[HasError] then "Expected : " & @ValueToText(expected[Error]) else expected[Value],
+        actual = try _actual,
+        safeActual = if actual[HasError] then "Actual : " & @ValueToText(actual[Error]) else actual[Value],
+        attempt = try safeExpected = safeActual,
+        result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+        resultOp = if result = "Success ✓" then " = " else " <> ",
+        addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+        addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+        addendumEvalActual = try @ValueToText(safeActual) otherwise "...",
+        fact = [
+            Result = result & " " & addendumEvalAttempt,
+            Notes = _subject,
+            Details = " (" & addendumEvalExpected & resultOp & addendumEvalActual & ")"
+        ]
+    ][fact];
 
-Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject, _{0}, _{1}));
 
 Facts.Summarize = (_facts as list) as table =>
-[   Fact.CountSuccesses = (count, i) =>
-    [   result = try i[Result],
-        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
-    ][sum],
-    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
-    total = List.Count(_facts),
-    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
-    result = if passed = total then "Success" else "⛔",
-    rate = Number.IntegerDivide(100*passed, total),
-    header =
-    [   Result = result,
-        Notes = Text.Format(format, {passed, total-passed}),
-        Details = Text.Format("#{0}% success rate", {rate})
-    ],
-    report = Table.FromRecords(List.Combine({{header},_facts}))
-][report];
+    [
+        Fact.CountSuccesses = (count, i) =>
+            [
+                result = try i[Result],
+                sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+            ][sum],
+        passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+        total = List.Count(_facts),
+        format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+        result = if passed = total then "Success" else "⛔",
+        rate = Number.IntegerDivide(100 * passed, total),
+        header = [
+            Result = result,
+            Notes = Text.Format(format, {passed, total - passed}),
+            Details = Text.Format("#{0}% success rate", {rate})
+        ],
+        report = Table.FromRecords(List.Combine({{header}, _facts}))
+    ][report];
 
 ValueToText = (value, optional depth) =>
     let
-        List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-        Serialize.Function =    (x) => _serialize_function_param_type(
-                                          Type.FunctionParameters(Value.Type(x)),
-                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                       " as " &
-                                       _serialize_function_return_type(Value.Type(x)) &
-                                       " => (...) ",
-
-        Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-        Serialize.Record =      (x) => "[ " &
-                                       List.TransformAndCombine(
-                                            Record.FieldNames(x), 
-                                            (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                            ", ") &
-                                       " ] ",
-
-        Serialize.Table =       (x) => "#table( type " &
-                                        _serialize_table_type(Value.Type(x)) &
-                                        ", " &
-                                        Serialize(Table.ToRows(x)) &
-                                        ") ",
-                                    
-        Serialize.Identifier =  Expression.Identifier,
-
-        Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                    let
-                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                    in
-                                
-                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                        if x = type any then "any" else
-                                        let base = Type.NonNullable(x) in
-                                          (if Type.IsNullable(x) then "nullable " else "") &       
-                                          (if base = type anynonnull then "anynonnull" else                
-                                          if base = type binary then "binary" else                
-                                          if base = type date   then "date"   else
-                                          if base = type datetime then "datetime" else
-                                          if base = type datetimezone then "datetimezone" else
-                                          if base = type duration then "duration" else
-                                          if base = type logical then "logical" else
-                                          if base = type none then "none" else
-                                          if base = type null then "null" else
-                                          if base = type number then "number" else
-                                          if base = type text then "text" else 
-                                          if base = type time then "time" else 
-                                          if base = type type then "type" else 
-                                      
-                                          /* Abstract types: */
-                                          if base = type function then "function" else
-                                          if base = type table then "table" else
-                                          if base = type record then "record" else
-                                          if base = type list then "list" else
-                                      
-                                          "any /*Actually unknown type*/"),
-
-        _serialize_table_type =     (x) => 
-                                           let 
-                                             schema = Type.TableSchema(x)
-                                           in
-                                             "table " &
-                                             (if Table.IsEmpty(schema) then "" else 
-                                                 "[" & List.TransformAndCombine(
-                                                     Table.ToRecords(Table.Sort(schema,"Position")),
-                                                     each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                     ", ") &
-                                                 "] "),
-
-        _serialize_record_type =    (x) => 
-                                            let flds = Type.RecordFields(x)
-                                            in
-                                                if Record.FieldCount(flds)=0 then "record" else
-                                                    "[" & List.TransformAndCombine(
-                                                        Record.FieldNames(flds),
-                                                        (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                        ", ") & 
-                                                    (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                    "]",
-
-        _serialize_function_type =  (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(x),
-                                              Type.FunctionRequiredParameters(x) ) &
-                                            " as " &
-                                            _serialize_function_return_type(x),
-    
-        _serialize_function_param_type = (t,n) => 
-                                let
-                                    funsig = Table.ToRecords(
-                                        Table.TransformColumns(
-                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                            { "isOptional", (x)=> x>n } ) )
-                                in
-                                    "(" & 
-                                    List.TransformAndCombine(
-                                        funsig,
-                                        (item)=>
-                                            (if item[isOptional] then "optional " else "") &
-                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                        ", ") &
-                                     ")",
-
-        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-        Serialize = (x) as text => 
-                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                           if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                           if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                           if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                           "[#_unable_to_serialize_#]"                     
+        List.TransformAndCombine = (list, transform, separator) =>
+            Text.Combine(List.Transform(list, transform), separator),
+        Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+        Serialize.Function = (x) =>
+            _serialize_function_param_type(
+                Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+            )
+                & " as "
+                & _serialize_function_return_type(Value.Type(x))
+                & " => (...) ",
+        Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+        Serialize.Record = (x) =>
+            "[ "
+                & List.TransformAndCombine(
+                    Record.FieldNames(x),
+                    (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                    ", "
+                )
+                & " ] ",
+        Serialize.Table = (x) =>
+            "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+        Serialize.Identifier = Expression.Identifier,
+        Serialize.Type = (x) => "type " & _serialize_typename(x),
+        _serialize_typename = (x, optional funtype as logical) =>
+            // Optional parameter: Is this being used as part of a function signature?
+            let
+                isFunctionType = (x as type) =>
+                    try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                isTableType = (x as type) => try if Type.TableSchema(x) is table then true else false otherwise false,
+                isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false
+            otherwise
+                false,
+                isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+            in
+                if funtype = null and isTableType(x) then
+                    _serialize_table_type(x)
+                else if funtype = null and isListType(x) then
+                    "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                else if funtype = null and isFunctionType(x) then
+                    "function " & _serialize_function_type(x)
+                else if funtype = null and isRecordType(x) then
+                    _serialize_record_type(x)
+                else if x = type any then
+                    "any"
+                else
+                    let
+                        base = Type.NonNullable(x)
+                    in
+                        (if Type.IsNullable(x) then "nullable " else "")
+                            & (
+                                if base = type anynonnull then
+                                    "anynonnull"
+                                else if base = type binary then
+                                    "binary"
+                                else if base = type date then
+                                    "date"
+                                else if base = type datetime then
+                                    "datetime"
+                                else if base = type datetimezone then
+                                    "datetimezone"
+                                else if base = type duration then
+                                    "duration"
+                                else if base = type logical then
+                                    "logical"
+                                else if base = type none then
+                                    "none"
+                                else if base = type null then
+                                    "null"
+                                else if base = type number then
+                                    "number"
+                                else if base = type text then
+                                    "text"
+                                else if base = type time then
+                                    "time"
+                                else if base = type type then
+                                    "type"
+                                else
+                                // Abstract types
+                                if base = type function then
+                                    "function"
+                                else if base = type table then
+                                    "table"
+                                else if base = type record then
+                                    "record"
+                                else if base = type list then
+                                    "list"
+                                else
+                                    "any /*Actually unknown type*/"
+                            ),
+        _serialize_table_type = (x) =>
+            let
+                schema = Type.TableSchema(x)
+            in
+                "table "
+                    & (
+                        if Table.IsEmpty(schema) then
+                            ""
+                        else
+                            "["
+                                & List.TransformAndCombine(
+                                    Table.ToRecords(Table.Sort(schema, "Position")),
+                                    each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                    ", "
+                                )
+                                & "] "
+                    ),
+        _serialize_record_type = (x) =>
+            let
+                flds = Type.RecordFields(x)
+            in
+                if Record.FieldCount(flds) = 0 then
+                    "record"
+                else
+                    "["
+                        & List.TransformAndCombine(
+                            Record.FieldNames(flds),
+                            (item) =>
+                                Serialize.Identifier(item) & "=" & _serialize_typename(
+                                    Record.Field(flds, item)[Type]
+                                ),
+                            ", "
+                        )
+                        & (if Type.IsOpenRecord(x) then ", ..." else "")
+                        & "]",
+        _serialize_function_type = (x) =>
+            _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                & " as "
+                & _serialize_function_return_type(x),
+        _serialize_function_param_type = (t, n) =>
+            let
+                funsig = Table.ToRecords(
+                    Table.TransformColumns(
+                        Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                    )
+                )
+            in
+                "("
+                    & List.TransformAndCombine(
+                        funsig,
+                        (item) =>
+                            (if item[isOptional] then "optional " else "")
+                                & Serialize.Identifier(item[Name])
+                                & " as "
+                                & _serialize_typename(item[Value], true),
+                        ", "
+                    )
+                    & ")",
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+        Serialize = (x) as text =>
+            if x is binary then
+                try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+            else if x is date then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetime then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetimezone then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is duration then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is function then
+                try Serialize.Function(x) otherwise "null /*serialize failed*/"
+            else if x is list then
+                try Serialize.List(x) otherwise "null /*serialize failed*/"
+            else if x is logical then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is null then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is number then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is record then
+                try Serialize.Record(x) otherwise "null /*serialize failed*/"
+            else if x is table then
+                try Serialize.Table(x) otherwise "null /*serialize failed*/"
+            else if x is text then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is time then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is type then
+                try Serialize.Type(x) otherwise "null /*serialize failed*/"
+            else
+                "[#_unable_to_serialize_#]"
     in
         try Serialize(value) otherwise "<serialization failed>";

--- a/samples/TripPin/2-Rest/TripPin.pq
+++ b/samples/TripPin/2-Rest/TripPin.pq
@@ -1,17 +1,18 @@
 ﻿section TripPin;
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Feed = Value.ReplaceType(TripPinImpl, type function (url as Uri.Type) as any);
 
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 TripPinImpl = (url as text) =>
     let
-        source = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),
-        json = Json.Document(source)
+        source = Web.Contents(url, [Headers = DefaultRequestHeaders]), json = Json.Document(source)
     in
         json;
 
@@ -27,6 +28,5 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin REST", "TripPin REST" }
+    ButtonText = {"TripPin REST", "TripPin REST"}
 ];
-

--- a/samples/TripPin/2-Rest/TripPin.query.pq
+++ b/samples/TripPin/2-Rest/TripPin.query.pq
@@ -1,5 +1,2 @@
 ﻿// Use this file to write queries to test your data connector
-let
-    result = TripPin.Feed("http://services.odata.org/v4/TripPinService/Me")
-in
-    result
+let result = TripPin.Feed("http://services.odata.org/v4/TripPinService/Me") in result

--- a/samples/TripPin/3-NavTables/TripPin.pq
+++ b/samples/TripPin/3-NavTables/TripPin.pq
@@ -3,7 +3,6 @@
 //
 // Definition
 //
-
 // Data Source Kind description
 TripPin = [
     Authentication = [
@@ -16,37 +15,40 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin Navigator", "TripPin Navigator" }
+    ButtonText = {"TripPin Navigator", "TripPin Navigator"}
 ];
 
 //
 // Implementation
-// 
-
-[DataSource.Kind="TripPin"]
+//
+[DataSource.Kind = "TripPin"]
 shared TripPin.Feed = Value.ReplaceType(TripPinImpl, type function (url as Uri.Type) as any);
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
-shared TripPin.Contents =  Value.ReplaceType(TripPinNavTable, type function (url as Uri.Type) as any);
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
+shared TripPin.Contents = Value.ReplaceType(TripPinNavTable, type function (url as Uri.Type) as any);
 
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 TripPinImpl = (url as text) =>
     let
-        source = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),
-        json = Json.Document(source)
+        source = Web.Contents(url, [Headers = DefaultRequestHeaders]), json = Json.Document(source)
     in
         json;
 
 TripPinNavTable = (url as text) as table =>
     let
-        source = #table({"Name", "Data", "ItemKind", "ItemName", "IsLeaf"}, {
-            { "Airlines", GetAirlinesTable(url), "Table", "Table", true },
-            { "Airports", GetAirportsTable(url), "Table", "Table", true }
-        }),
+        source = #table(
+            {"Name", "Data", "ItemKind", "ItemName", "IsLeaf"},
+            {
+                {"Airlines", GetAirlinesTable(url), "Table", "Table", true},
+                {"Airports", GetAirportsTable(url), "Table", "Table", true}
+            }
+        ),
         navTable = Table.ToNavigationTable(source, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
     in
         navTable;
@@ -65,15 +67,37 @@ GetAirportsTable = (url as text) as table =>
         source = TripPin.Feed(url & "Airports"),
         value = source[value],
         #"Converted to Table" = Table.FromList(value, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
-        #"Expanded Column1" = Table.ExpandRecordColumn(#"Converted to Table", "Column1", {"Name", "IcaoCode", "IataCode", "Location"}, {"Name", "IcaoCode", "IataCode", "Location"}),
-        #"Expanded Location" = Table.ExpandRecordColumn(#"Expanded Column1", "Location", {"Address", "Loc", "City"}, {"Address", "Loc", "City"}),
-        #"Expanded City" = Table.ExpandRecordColumn(#"Expanded Location", "City", {"Name", "CountryRegion", "Region"}, {"Name.1", "CountryRegion", "Region"}),
-        #"Renamed Columns" = Table.RenameColumns(#"Expanded City",{{"Name.1", "City"}}),
+        #"Expanded Column1" = Table.ExpandRecordColumn(
+            #"Converted to Table",
+            "Column1",
+            {"Name", "IcaoCode", "IataCode", "Location"},
+            {"Name", "IcaoCode", "IataCode", "Location"}
+        ),
+        #"Expanded Location" = Table.ExpandRecordColumn(
+            #"Expanded Column1", "Location", {"Address", "Loc", "City"}, {"Address", "Loc", "City"}
+        ),
+        #"Expanded City" = Table.ExpandRecordColumn(
+            #"Expanded Location", "City", {"Name", "CountryRegion", "Region"}, {"Name.1", "CountryRegion", "Region"}
+        ),
+        #"Renamed Columns" = Table.RenameColumns(#"Expanded City", {{"Name.1", "City"}}),
         #"Expanded Loc" = Table.ExpandRecordColumn(#"Renamed Columns", "Loc", {"coordinates"}, {"coordinates"}),
-        #"Added Custom" = Table.AddColumn(#"Expanded Loc", "Latitude", each [coordinates]{1}),
-        #"Added Custom1" = Table.AddColumn(#"Added Custom", "Longitude", each [coordinates]{0}),
-        #"Removed Columns" = Table.RemoveColumns(#"Added Custom1",{"coordinates"}),
-        #"Changed Type" = Table.TransformColumnTypes(#"Removed Columns",{{"Name", type text}, {"IcaoCode", type text}, {"IataCode", type text}, {"Address", type text}, {"City", type text}, {"CountryRegion", type text}, {"Region", type text}, {"Latitude", type number}, {"Longitude", type number}})
+        #"Added Custom" = Table.AddColumn(#"Expanded Loc", "Latitude", each[coordinates]{1}),
+        #"Added Custom1" = Table.AddColumn(#"Added Custom", "Longitude", each[coordinates]{0}),
+        #"Removed Columns" = Table.RemoveColumns(#"Added Custom1", {"coordinates"}),
+        #"Changed Type" = Table.TransformColumnTypes(
+            #"Removed Columns",
+            {
+                {"Name", type text},
+                {"IcaoCode", type text},
+                {"IataCode", type text},
+                {"Address", type text},
+                {"City", type text},
+                {"CountryRegion", type text},
+                {"Region", type text},
+                {"Latitude", type number},
+                {"Longitude", type number}
+            }
+        )
     in
         #"Changed Type";
 
@@ -91,12 +115,11 @@ Table.ToNavigationTable = (
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)

--- a/samples/TripPin/3-NavTables/TripPin.query.pq
+++ b/samples/TripPin/3-NavTables/TripPin.query.pq
@@ -1,1 +1,1 @@
-﻿ TripPin.Contents("http://services.odata.org/v4/TripPinService/")
+﻿TripPin.Contents("http://services.odata.org/v4/TripPinService/")

--- a/samples/TripPin/4-Paths/TripPin.pq
+++ b/samples/TripPin/4-Paths/TripPin.pq
@@ -3,7 +3,6 @@
 //
 // Definition
 //
-
 // Data Source Kind description
 TripPin = [
     Authentication = [
@@ -16,27 +15,24 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin Data Source Paths", "TripPin Data Source Paths" }
+    ButtonText = {"TripPin Data Source Paths", "TripPin Data Source Paths"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
-RootEntities = {
-    "Airlines",
-    "Airports",
-    "People"
-};
+RootEntities = {"Airlines", "Airports", "People"};
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -57,7 +53,7 @@ TripPinNavTable = (url as text) as table =>
 
 TripPin.Feed = (url as text) =>
     let
-        source = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),
+        source = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         json = Json.Document(source),
         // The response is a JSON record - the data we want is a list of records in the "value" field
         value = json[value],
@@ -82,17 +78,13 @@ Table.ToNavigationTable = (
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)
     in
         navigationTable;
-
-
-

--- a/samples/TripPin/5-Paging/TripPin.pq
+++ b/samples/TripPin/5-Paging/TripPin.pq
@@ -3,7 +3,6 @@
 //
 // Definition
 //
-
 // Data Source Kind description
 TripPin = [
     Authentication = [
@@ -16,27 +15,24 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin Paging", "TripPin Paging" }
+    ButtonText = {"TripPin Paging", "TripPin Paging"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
-RootEntities = {
-    "Airlines",
-    "Airports",
-    "People"
-};
+RootEntities = {"Airlines", "Airports", "People"};
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -59,7 +55,7 @@ TripPin.Feed = (url as text) as table => GetAllPagesByNextLink(url);
 
 GetPage = (url as text) as table =>
     let
-        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        response = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         body = Json.Document(response),
         nextLink = GetNextLink(body),
         data = Table.FromRecords(body[value])
@@ -70,14 +66,15 @@ GetPage = (url as text) as table =>
 // After every page, we check the "NextLink" record on the metadata of the previous request.
 // Table.GenerateByPage will keep asking for more pages until we return null.
 GetAllPagesByNextLink = (url as text) as table =>
-    Table.GenerateByPage((previous) => 
-        let
-            // if previous is null, then this is our first page of data
-            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
-            // if NextLink was set to null by the previous call, we know we have no more data
-            page = if (nextLink <> null) then GetPage(nextLink) else null
-        in
-            page
+    Table.GenerateByPage(
+        (previous) =>
+            let
+                // if previous is null, then this is our first page of data
+                nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+                // if NextLink was set to null by the previous call, we know we have no more data
+                page = if (nextLink <> null) then GetPage(nextLink) else null
+            in
+                page
     );
 
 // In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
@@ -98,12 +95,11 @@ Table.ToNavigationTable = (
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)
@@ -112,21 +108,24 @@ Table.ToNavigationTable = (
 
 // The getNextPage function takes a single argument and is expected to return a nullable table
 Table.GenerateByPage = (getNextPage as function) as table =>
-    let        
+    let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+            // get the first page of data
+            () => getNextPage(null),
+            // stop when the function returns null
+            (lastPage) => lastPage <> null,
+            // pass the previous page to the next function call
+            (lastPage) => getNextPage(lastPage)
         ),
         // concatenate the pages together
         tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = tableOfPages{0} ?
     in
         // if we didn't get back any pages of data, return an empty table
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-        else        
+        else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
                 Value.Type(firstRow[Column1])

--- a/samples/TripPin/5-Paging/TripPin.query.pq
+++ b/samples/TripPin/5-Paging/TripPin.query.pq
@@ -1,6 +1,6 @@
 ﻿let
     source = TripPin.Contents(),
-    data = source{[Name="People"]}[Data],
+    data = source{[Name = "People"]}[Data],
     withRowCount = Table.AddIndexColumn(data, "Index")
 in
     withRowCount

--- a/samples/TripPin/6-Schema/TripPin.pq
+++ b/samples/TripPin/6-Schema/TripPin.pq
@@ -3,7 +3,6 @@
 //
 // Definition
 //
-
 // Data Source Kind description
 TripPin = [
     Authentication = [
@@ -16,53 +15,56 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin Schema", "TripPin Schema" }
+    ButtonText = {"TripPin Schema", "TripPin Schema"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
-RootEntities = {
-    "Airlines",
-    "Airports",
-    "People"
-};
+RootEntities = {"Airlines", "Airports", "People"};
 
-SchemaTable = #table({"Entity", "SchemaTable"}, {
-    {"Airlines", #table({"Name", "Type"}, {
-        {"AirlineCode", type text},
-        {"Name", type text}
-    })},    
-    
-    {"Airports", #table({"Name", "Type"}, {
-        {"IcaoCode", type text},
-        {"Name", type text},
-        {"IataCode", type text},
-        {"Location", type record}
-    })},
+SchemaTable = #table(
+    {"Entity", "SchemaTable"},
+    {
+        {"Airlines", #table({"Name", "Type"}, {{"AirlineCode", type text}, {"Name", type text}})},
+        {
+            "Airports",
+            #table(
+                {"Name", "Type"},
+                {{"IcaoCode", type text}, {"Name", type text}, {"IataCode", type text}, {"Location", type record}}
+            )
+        },
+        {
+            "People",
+            #table(
+                {"Name", "Type"},
+                {
+                    {"UserName", type text},
+                    {"FirstName", type text},
+                    {"LastName", type text},
+                    {"Emails", type list},
+                    {"AddressInfo", type list},
+                    {"Gender", type nullable text},
+                    {"Concurrency", Int64.Type}
+                }
+            )
+        }
+    }
+);
 
-    {"People", #table({"Name", "Type"}, {
-        {"UserName", type text},
-        {"FirstName", type text},
-        {"LastName", type text},
-        {"Emails", type list},
-        {"AddressInfo", type list},
-        {"Gender", type nullable text},
-        {"Concurrency", Int64.Type}
-    })}
-});
-        
-GetSchemaForEntity = (entity as text) as table => try SchemaTable{[Entity=entity]}[SchemaTable] otherwise error "Couldn't find entity: '" & entity &"'";
+GetSchemaForEntity = (entity as text) as table =>
+    try SchemaTable{[Entity = entity]}[SchemaTable] otherwise error "Couldn't find entity: '" & entity & "'";
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -83,7 +85,7 @@ TripPinNavTable = (url as text) as table =>
 
 TripPin.Feed = (url as text, optional schema as table) as table => GetAllPagesByNextLink(url, schema);
 
-GetEntity = (url as text, entity as text) as table => 
+GetEntity = (url as text, entity as text) as table =>
     let
         fullUrl = Uri.Combine(url, entity),
         schemaTable = GetSchemaForEntity(entity),
@@ -93,7 +95,7 @@ GetEntity = (url as text, entity as text) as table =>
 
 GetPage = (url as text, optional schema as table) as table =>
     let
-        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        response = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         body = Json.Document(response),
         nextLink = GetNextLink(body),
         data = Table.FromRecords(body[value], schema[Name], MissingField.UseNull),
@@ -106,14 +108,15 @@ GetPage = (url as text, optional schema as table) as table =>
 // After every page, we check the "NextLink" record on the metadata of the previous request.
 // Table.GenerateByPage will keep asking for more pages until we return null.
 GetAllPagesByNextLink = (url as text, optional schema as table) as table =>
-    Table.GenerateByPage((previous) => 
-        let
-            // if previous is null, then this is our first page of data
-            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
-            // if NextLink was set to null by the previous call, we know we have no more data
-            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
-        in
-            page
+    Table.GenerateByPage(
+        (previous) =>
+            let
+                // if previous is null, then this is our first page of data
+                nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+                // if NextLink was set to null by the previous call, we know we have no more data
+                page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+            in
+                page
     );
 
 // In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
@@ -134,12 +137,11 @@ Table.ToNavigationTable = (
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)
@@ -148,21 +150,24 @@ Table.ToNavigationTable = (
 
 // The getNextPage function takes a single argument and is expected to return a nullable table
 Table.GenerateByPage = (getNextPage as function) as table =>
-    let        
+    let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+            // get the first page of data
+            () => getNextPage(null),
+            // stop when the function returns null
+            (lastPage) => lastPage <> null,
+            // pass the previous page to the next function call
+            (lastPage) => getNextPage(lastPage)
         ),
         // concatenate the pages together
         tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = tableOfPages{0} ?
     in
         // if we didn't get back any pages of data, return an empty table
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-        else        
+        else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
                 Value.Type(firstRow[Column1])
@@ -171,16 +176,17 @@ Table.GenerateByPage = (getNextPage as function) as table =>
 //
 // Schema functions
 //
-
-EnforceSchema.Strict = 1;               // Add any missing columns, remove extra columns, set table type
-EnforceSchema.IgnoreExtraColumns = 2;   // Add missing columns, do not remove extra columns
-EnforceSchema.IgnoreMissingColumns = 3; // Do not add or remove columns
+// Add any missing columns, remove extra columns, set table type
+EnforceSchema.Strict = 1;
+// Add missing columns, do not remove extra columns
+EnforceSchema.IgnoreExtraColumns = 2;
+// Do not add or remove columns
+EnforceSchema.IgnoreMissingColumns = 3;
 
 SchemaTransformTable = (table as table, schema as table, optional enforceSchema as number) as table =>
     let
         // Default to EnforceSchema.Strict
         _enforceSchema = if (enforceSchema <> null) then enforceSchema else EnforceSchema.Strict,
-
         // Applies type transforms to a given table
         EnforceTypes = (table as table, schema as table) as table =>
             let
@@ -193,16 +199,14 @@ SchemaTransformTable = (table as table, schema as table, optional enforceSchema 
                 changedPrimitives = Table.TransformColumnTypes(table, primitiveTransforms)
             in
                 changedPrimitives,
-
         // Returns the table type for a given schema
         SchemaToTableType = (schema as table) as type =>
             let
-                toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+                toList = List.Transform(schema[Type], (t) => [Type = t, Optional = false]),
                 toRecord = Record.FromList(toList, schema[Name]),
                 toType = Type.ForRecord(toRecord, false)
             in
                 type table (toType),
-
         // Determine if we have extra/missing columns.
         // The enforceSchema parameter determines what we do about them.
         schemaNames = schema[Name],
@@ -220,11 +224,14 @@ SchemaTransformTable = (table as table, schema as table, optional enforceSchema 
                 foundNames
             else
                 schemaNames & extraNames,
-
         // Select the final list of columns.
         // These will be ordered according to the schema table.
         reordered = Table.SelectColumns(result, fullList, MissingField.Ignore),
         enforcedTypes = EnforceTypes(reordered, schema),
-        withType = if (_enforceSchema = EnforceSchema.Strict) then Value.ReplaceType(enforcedTypes, SchemaToTableType(schema)) else enforcedTypes
+        withType =
+            if (_enforceSchema = EnforceSchema.Strict) then
+                Value.ReplaceType(enforcedTypes, SchemaToTableType(schema))
+            else
+                enforcedTypes
     in
         withType;

--- a/samples/TripPin/6-Schema/TripPin.query.pq
+++ b/samples/TripPin/6-Schema/TripPin.query.pq
@@ -1,5 +1,1 @@
-﻿let
-    source = TripPin.Contents(),
-    data = source{[Name="People"]}[Data]
-in
-    Table.Schema(data)
+﻿let source = TripPin.Contents(), data = source{[Name = "People"]}[Data] in Table.Schema(data)

--- a/samples/TripPin/7-AdvancedSchema/Table.GenerateByPage.pqm
+++ b/samples/TripPin/7-AdvancedSchema/Table.GenerateByPage.pqm
@@ -1,21 +1,24 @@
 ﻿(getNextPage as function) as table =>
-    let        
+    let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+            // get the first page of data
+            () => getNextPage(null),
+            // stop when the function returns null
+            (lastPage) => lastPage <> null,
+            // pass the previous page to the next function call
+            (lastPage) => getNextPage(lastPage)
         ),
         // concatenate the pages together
         tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = tableOfPages{0} ?
     in
         // if we didn't get back any pages of data, return an empty table
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-		// check for empty first table
-		else if (Table.IsEmpty(firstRow[Column1])) then
-			firstRow[Column1]
+            // check for empty first table
+        else if (Table.IsEmpty(firstRow[Column1])) then
+            firstRow[Column1]
         else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),

--- a/samples/TripPin/7-AdvancedSchema/Table.ToNavigationTable.pqm
+++ b/samples/TripPin/7-AdvancedSchema/Table.ToNavigationTable.pqm
@@ -9,12 +9,11 @@
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)

--- a/samples/TripPin/7-AdvancedSchema/TripPin.pq
+++ b/samples/TripPin/7-AdvancedSchema/TripPin.pq
@@ -12,28 +12,25 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin Advanced Schema", "TripPin Advanced Schema" }
+    ButtonText = {"TripPin Advanced Schema", "TripPin Advanced Schema"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
 // Define our top level table types
-AirlinesType = type table [ AirlineCode = text, Name = text ];
+AirlinesType = type table [AirlineCode = text, Name = text];
 
-AirportsType = type table [
-    Name = text,
-    IataCode = text,
-    Location = LocationType
-];
+AirportsType = type table [Name = text, IataCode = text, Location = LocationType];
 
 PeopleType = type table [
     UserName = text,
@@ -46,38 +43,22 @@ PeopleType = type table [
 ];
 
 // remaining structured types
-LocationType = type [
-    Address = text,
-    City = CityType,
-    Loc = LocType
-];
+LocationType = type [Address = text, City = CityType, Loc = LocType];
 
-CityType = type [
-    CountryRegion = text,
-    Name = text,
-    Region = text
-];
+CityType = type [CountryRegion = text, Name = text, Region = text];
 
-LocType = type [
-    #"type" = text,
-    coordinates = {number},
-    crs = CrsType
-];
+LocType = type [#"type" = text, coordinates = {number}, crs = CrsType];
 
-CrsType = type [
-    #"type" = text,
-    properties = record
-];
+CrsType = type [#"type" = text, properties = record];
 
-SchemaTable = #table({"Entity", "Type"}, {
-    {"Airlines", AirlinesType },    
-    {"Airports", AirportsType },
-    {"People", PeopleType}    
-});
-        
-GetSchemaForEntity = (entity as text) as type => try SchemaTable{[Entity=entity]}[Type] otherwise error "Couldn't find entity: '" & entity &"'";
+SchemaTable = #table(
+    {"Entity", "Type"}, {{"Airlines", AirlinesType}, {"Airports", AirportsType}, {"People", PeopleType}}
+);
 
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+GetSchemaForEntity = (entity as text) as type =>
+    try SchemaTable{[Entity = entity]}[Type] otherwise error "Couldn't find entity: '" & entity & "'";
+
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -99,7 +80,7 @@ TripPinNavTable = (url as text) as table =>
 
 TripPin.Feed = (url as text, optional schema as type) as table => GetAllPagesByNextLink(url, schema);
 
-GetEntity = (url as text, entity as text) as table => 
+GetEntity = (url as text, entity as text) as table =>
     let
         fullUrl = Uri.Combine(url, entity),
         schema = GetSchemaForEntity(entity),
@@ -110,10 +91,9 @@ GetEntity = (url as text, entity as text) as table =>
 
 GetPage = (url as text, optional schema as type) as table =>
     let
-        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        response = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         body = Json.Document(response),
         nextLink = GetNextLink(body),
-        
         // If we have no schema, use Table.FromRecords() instead
         // (and hope that our results all have the same fields).
         // If we have a schema, expand the record using its field names
@@ -135,28 +115,28 @@ GetPage = (url as text, optional schema as type) as table =>
 // After every page, we check the "NextLink" record on the metadata of the previous request.
 // Table.GenerateByPage will keep asking for more pages until we return null.
 GetAllPagesByNextLink = (url as text, optional schema as type) as table =>
-    Table.GenerateByPage((previous) => 
-        let
-            // if previous is null, then this is our first page of data
-            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
-            // if NextLink was set to null by the previous call, we know we have no more data
-            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
-        in
-            page
+    Table.GenerateByPage(
+        (previous) =>
+            let
+                // if previous is null, then this is our first page of data
+                nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+                // if NextLink was set to null by the previous call, we know we have no more data
+                page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+            in
+                page
     );
 
 // In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
 // We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
 GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
 
-// 
+//
 // Load common library functions
-// 
+//
 // TEMPORARY WORKAROUND until we're able to reference other M modules
 Extension.LoadFunction = (name as text) =>
     let
-        binary = Extension.Contents(name),
-        asText = Text.FromBinary(binary)
+        binary = Extension.Contents(name), asText = Text.FromBinary(binary)
     in
         Expression.Evaluate(asText, #shared);
 

--- a/samples/TripPin/7-AdvancedSchema/TripPin.query.pq
+++ b/samples/TripPin/7-AdvancedSchema/TripPin.query.pq
@@ -1,205 +1,253 @@
 ﻿section TripPinUnitTests;
 
-shared TripPin.UnitTest =
-[
+shared TripPin.UnitTest = [
     // Put any common variables here if you only want them to be evaluated once
     RootTable = TripPin.Contents(),
-    Airlines = RootTable{[Name="Airlines"]}[Data],
-    Airports = RootTable{[Name="Airports"]}[Data],
-    People = RootTable{[Name="People"]}[Data],
-
+    Airlines = RootTable{[Name = "Airlines"]}[Data],
+    Airports = RootTable{[Name = "Airports"]}[Data],
+    People = RootTable{[Name = "People"]}[Data],
     // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
     // <Expected Value> and <Actual Value> can be a literal or let statement
-    facts =
-    {
+    facts = {
         Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
         Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
         Fact("We have People data?", true, not Table.IsEmpty(People)),
-        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
-        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
-        Fact("Airline table has the right fields",
-            {"AirlineCode","Name"},
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),
+        Fact(
+            "Airline table has the right fields",
+            {"AirlineCode", "Name"},
             Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
         ),
         Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails])))
     },
-
     report = Facts.Summarize(facts)
 ][report];
 
-/// COMMON UNIT TESTING CODE 
+/// COMMON UNIT TESTING CODE
 Fact = (_subject as text, _expected, _actual) as record =>
-[   expected = try _expected,
-    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
-    actual = try _actual,
-    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
-    attempt = try safeExpected = safeActual,
-    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
-    resultOp = if result = "Success ✓" then " = " else " <> ",
-    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
-    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
-    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
-    fact =
-    [   Result = result &" "& addendumEvalAttempt,
-        Notes =_subject,
-        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
-    ]
-][fact];
+    [
+        expected = try _expected,
+        safeExpected = if expected[HasError] then "Expected : " & @ValueToText(expected[Error]) else expected[Value],
+        actual = try _actual,
+        safeActual = if actual[HasError] then "Actual : " & @ValueToText(actual[Error]) else actual[Value],
+        attempt = try safeExpected = safeActual,
+        result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+        resultOp = if result = "Success ✓" then " = " else " <> ",
+        addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+        addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+        addendumEvalActual = try @ValueToText(safeActual) otherwise "...",
+        fact = [
+            Result = result & " " & addendumEvalAttempt,
+            Notes = _subject,
+            Details = " (" & addendumEvalExpected & resultOp & addendumEvalActual & ")"
+        ]
+    ][fact];
 
-Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject, _{0}, _{1}));
 
 Facts.Summarize = (_facts as list) as table =>
-[   Fact.CountSuccesses = (count, i) =>
-    [   result = try i[Result],
-        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
-    ][sum],
-    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
-    total = List.Count(_facts),
-    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
-    result = if passed = total then "Success" else "⛔",
-    rate = Number.IntegerDivide(100*passed, total),
-    header =
-    [   Result = result,
-        Notes = Text.Format(format, {passed, total-passed}),
-        Details = Text.Format("#{0}% success rate", {rate})
-    ],
-    report = Table.FromRecords(List.Combine({{header},_facts}))
-][report];
+    [
+        Fact.CountSuccesses = (count, i) =>
+            [
+                result = try i[Result],
+                sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+            ][sum],
+        passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+        total = List.Count(_facts),
+        format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+        result = if passed = total then "Success" else "⛔",
+        rate = Number.IntegerDivide(100 * passed, total),
+        header = [
+            Result = result,
+            Notes = Text.Format(format, {passed, total - passed}),
+            Details = Text.Format("#{0}% success rate", {rate})
+        ],
+        report = Table.FromRecords(List.Combine({{header}, _facts}))
+    ][report];
 
 ValueToText = (value, optional depth) =>
     let
-        List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-        Serialize.Function =    (x) => _serialize_function_param_type(
-                                          Type.FunctionParameters(Value.Type(x)),
-                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                       " as " &
-                                       _serialize_function_return_type(Value.Type(x)) &
-                                       " => (...) ",
-
-        Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-        Serialize.Record =      (x) => "[ " &
-                                       List.TransformAndCombine(
-                                            Record.FieldNames(x), 
-                                            (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                            ", ") &
-                                       " ] ",
-
-        Serialize.Table =       (x) => "#table( type " &
-                                        _serialize_table_type(Value.Type(x)) &
-                                        ", " &
-                                        Serialize(Table.ToRows(x)) &
-                                        ") ",
-                                    
-        Serialize.Identifier =  Expression.Identifier,
-
-        Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                    let
-                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                    in
-                                
-                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                        if x = type any then "any" else
-                                        let base = Type.NonNullable(x) in
-                                          (if Type.IsNullable(x) then "nullable " else "") &       
-                                          (if base = type anynonnull then "anynonnull" else                
-                                          if base = type binary then "binary" else                
-                                          if base = type date   then "date"   else
-                                          if base = type datetime then "datetime" else
-                                          if base = type datetimezone then "datetimezone" else
-                                          if base = type duration then "duration" else
-                                          if base = type logical then "logical" else
-                                          if base = type none then "none" else
-                                          if base = type null then "null" else
-                                          if base = type number then "number" else
-                                          if base = type text then "text" else 
-                                          if base = type time then "time" else 
-                                          if base = type type then "type" else 
-                                      
-                                          /* Abstract types: */
-                                          if base = type function then "function" else
-                                          if base = type table then "table" else
-                                          if base = type record then "record" else
-                                          if base = type list then "list" else
-                                      
-                                          "any /*Actually unknown type*/"),
-
-        _serialize_table_type =     (x) => 
-                                           let 
-                                             schema = Type.TableSchema(x)
-                                           in
-                                             "table " &
-                                             (if Table.IsEmpty(schema) then "" else 
-                                                 "[" & List.TransformAndCombine(
-                                                     Table.ToRecords(Table.Sort(schema,"Position")),
-                                                     each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                     ", ") &
-                                                 "] "),
-
-        _serialize_record_type =    (x) => 
-                                            let flds = Type.RecordFields(x)
-                                            in
-                                                if Record.FieldCount(flds)=0 then "record" else
-                                                    "[" & List.TransformAndCombine(
-                                                        Record.FieldNames(flds),
-                                                        (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                        ", ") & 
-                                                    (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                    "]",
-
-        _serialize_function_type =  (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(x),
-                                              Type.FunctionRequiredParameters(x) ) &
-                                            " as " &
-                                            _serialize_function_return_type(x),
-    
-        _serialize_function_param_type = (t,n) => 
-                                let
-                                    funsig = Table.ToRecords(
-                                        Table.TransformColumns(
-                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                            { "isOptional", (x)=> x>n } ) )
-                                in
-                                    "(" & 
-                                    List.TransformAndCombine(
-                                        funsig,
-                                        (item)=>
-                                            (if item[isOptional] then "optional " else "") &
-                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                        ", ") &
-                                     ")",
-
-        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-        Serialize = (x) as text => 
-                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                           if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                           if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                           if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                           "[#_unable_to_serialize_#]"                     
+        List.TransformAndCombine = (list, transform, separator) =>
+            Text.Combine(List.Transform(list, transform), separator),
+        Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+        Serialize.Function = (x) =>
+            _serialize_function_param_type(
+                Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+            )
+                & " as "
+                & _serialize_function_return_type(Value.Type(x))
+                & " => (...) ",
+        Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+        Serialize.Record = (x) =>
+            "[ "
+                & List.TransformAndCombine(
+                    Record.FieldNames(x),
+                    (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                    ", "
+                )
+                & " ] ",
+        Serialize.Table = (x) =>
+            "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+        Serialize.Identifier = Expression.Identifier,
+        Serialize.Type = (x) => "type " & _serialize_typename(x),
+        _serialize_typename = (x, optional funtype as logical) =>
+            // Optional parameter: Is this being used as part of a function signature?
+            let
+                isFunctionType = (x as type) =>
+                    try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                isTableType = (x as type) => try if Type.TableSchema(x) is table then true else false otherwise false,
+                isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false
+            otherwise
+                false,
+                isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+            in
+                if funtype = null and isTableType(x) then
+                    _serialize_table_type(x)
+                else if funtype = null and isListType(x) then
+                    "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                else if funtype = null and isFunctionType(x) then
+                    "function " & _serialize_function_type(x)
+                else if funtype = null and isRecordType(x) then
+                    _serialize_record_type(x)
+                else if x = type any then
+                    "any"
+                else
+                    let
+                        base = Type.NonNullable(x)
+                    in
+                        (if Type.IsNullable(x) then "nullable " else "")
+                            & (
+                                if base = type anynonnull then
+                                    "anynonnull"
+                                else if base = type binary then
+                                    "binary"
+                                else if base = type date then
+                                    "date"
+                                else if base = type datetime then
+                                    "datetime"
+                                else if base = type datetimezone then
+                                    "datetimezone"
+                                else if base = type duration then
+                                    "duration"
+                                else if base = type logical then
+                                    "logical"
+                                else if base = type none then
+                                    "none"
+                                else if base = type null then
+                                    "null"
+                                else if base = type number then
+                                    "number"
+                                else if base = type text then
+                                    "text"
+                                else if base = type time then
+                                    "time"
+                                else if base = type type then
+                                    "type"
+                                else
+                                // Abstract types
+                                if base = type function then
+                                    "function"
+                                else if base = type table then
+                                    "table"
+                                else if base = type record then
+                                    "record"
+                                else if base = type list then
+                                    "list"
+                                else
+                                    "any /*Actually unknown type*/"
+                            ),
+        _serialize_table_type = (x) =>
+            let
+                schema = Type.TableSchema(x)
+            in
+                "table "
+                    & (
+                        if Table.IsEmpty(schema) then
+                            ""
+                        else
+                            "["
+                                & List.TransformAndCombine(
+                                    Table.ToRecords(Table.Sort(schema, "Position")),
+                                    each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                    ", "
+                                )
+                                & "] "
+                    ),
+        _serialize_record_type = (x) =>
+            let
+                flds = Type.RecordFields(x)
+            in
+                if Record.FieldCount(flds) = 0 then
+                    "record"
+                else
+                    "["
+                        & List.TransformAndCombine(
+                            Record.FieldNames(flds),
+                            (item) =>
+                                Serialize.Identifier(item) & "=" & _serialize_typename(
+                                    Record.Field(flds, item)[Type]
+                                ),
+                            ", "
+                        )
+                        & (if Type.IsOpenRecord(x) then ", ..." else "")
+                        & "]",
+        _serialize_function_type = (x) =>
+            _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                & " as "
+                & _serialize_function_return_type(x),
+        _serialize_function_param_type = (t, n) =>
+            let
+                funsig = Table.ToRecords(
+                    Table.TransformColumns(
+                        Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                    )
+                )
+            in
+                "("
+                    & List.TransformAndCombine(
+                        funsig,
+                        (item) =>
+                            (if item[isOptional] then "optional " else "")
+                                & Serialize.Identifier(item[Name])
+                                & " as "
+                                & _serialize_typename(item[Value], true),
+                        ", "
+                    )
+                    & ")",
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+        Serialize = (x) as text =>
+            if x is binary then
+                try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+            else if x is date then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetime then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetimezone then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is duration then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is function then
+                try Serialize.Function(x) otherwise "null /*serialize failed*/"
+            else if x is list then
+                try Serialize.List(x) otherwise "null /*serialize failed*/"
+            else if x is logical then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is null then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is number then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is record then
+                try Serialize.Record(x) otherwise "null /*serialize failed*/"
+            else if x is table then
+                try Serialize.Table(x) otherwise "null /*serialize failed*/"
+            else if x is text then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is time then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is type then
+                try Serialize.Type(x) otherwise "null /*serialize failed*/"
+            else
+                "[#_unable_to_serialize_#]"
     in
         try Serialize(value) otherwise "<serialization failed>";

--- a/samples/TripPin/8-Diagnostics/Diagnostics.pqm
+++ b/samples/TripPin/8-Diagnostics/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/TripPin/8-Diagnostics/Table.ChangeType.pqm
+++ b/samples/TripPin/8-Diagnostics/Table.ChangeType.pqm
@@ -2,79 +2,114 @@
     // table should be an actual Table.Type, or a List.Type of Records
     Table.ChangeType = (table, tableType as type) as nullable table =>
         // we only operate on table types
-        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        if (not Type.Is(tableType, type table)) then
+            error "type argument should be a table type"
+        else
         // if we have a null value, just return it
-        if (table = null) then table else
-        let
-            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
-            columnsAsTable = Record.ToTable(columnsForType),
-            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
-            previousMeta = Value.Metadata(tableType),
-
-            // make sure we have a table
-            parameterType = Value.Type(table),
-            _table =
-                if (Type.Is(parameterType, type table)) then table
-                else if (Type.Is(parameterType, type list)) then
-                    let
-                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
-                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
-                        result =
-                            // if the member is a record (as expected), then expand it. 
+        if (table = null) then
+            table
+        else
+            let
+                columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+                columnsAsTable = Record.ToTable(columnsForType),
+                schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+                previousMeta = Value.Metadata(tableType),
+                // make sure we have a table
+                parameterType = Value.Type(table),
+                _table =
+                    if (Type.Is(parameterType, type table)) then
+                        table
+                    else if (Type.Is(parameterType, type list)) then
+                        let
+                            asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                            firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                            result =
+                            // if the member is a record (as expected), then expand it.
                             if (Type.Is(firstValueType, type record)) then
                                 Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
                             else
-                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
-                    in
-                        if (List.IsEmpty(table)) then
-                            #table({"a"}, {})
-                        else result
+                                error
+                                    Error.Record(
+                                        "Error.Parameter",
+                                        "table argument is a list, but not a list of records",
+                                        [
+                                            ValueType = firstValueType
+                                        ]
+                                    )
+                        in
+                            if (List.IsEmpty(table)) then
+                                #table({"a"}, {})
+                            else
+                                result
+                    else
+                        error
+                            Error.Record(
+                                "Error.Parameter",
+                                "table argument should be a table or list of records",
+                                [
+                                    ValueType = parameterType
+                                ]
+                            ),
+                reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+                // process primitive values - this will call Table.TransformColumnTypes
+                map = (t) =>
+                    if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any
+                    then
+                        null
+                    else
+                        t,
+                mapped = Table.TransformColumns(schema, {"Type", map}),
+                omitted = Table.SelectRows(mapped, each [Type] <> null),
+                existingColumns = Table.ColumnNames(reordered),
+                removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+                primitiveTransforms = Table.ToRows(removeMissing),
+                changedPrimitives = Table.TransformColumnTypes(reordered, primitiveTransforms),
+                // Get the list of transforms we'll use for Record types
+                recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+                recordTypeTransformations = Table.AddColumn(
+                    recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function
+                ),
+                recordChanges = Table.ToRows(
+                    Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})
+                ),
+                // Get the list of transforms we'll use for List types
+                listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+                listTransforms = Table.AddColumn(
+                    listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type
+                ),
+                listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+                // Get the list of transforms we'll use for Table types
+                tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+                tableTransforms = Table.AddColumn(
+                    tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type
+                ),
+                tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+                // Perform all of our transformations
+                allColumnTransforms = recordChanges & listChanges & tableChanges,
+                changedRecordTypes =
+                    if (List.IsEmpty(allColumnTransforms)) then
+                        changedPrimitives
+                    else
+                        Table.TransformColumns(changedPrimitives, allColumnTransforms, null, MissingField.Ignore),
+                // set final type
+                withType = Value.ReplaceType(changedRecordTypes, tableType)
+            in
+                if (List.IsEmpty(Record.FieldNames(columnsForType))) then
+                    table
                 else
-                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
-
-            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
-
-            // process primitive values - this will call Table.TransformColumnTypes
-            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
-            mapped = Table.TransformColumns(schema, {"Type", map}),
-            omitted = Table.SelectRows(mapped, each [Type] <> null),
-            existingColumns = Table.ColumnNames(reordered),
-            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
-            primitiveTransforms = Table.ToRows(removeMissing),
-            changedPrimitives = Table.TransformColumnTypes(reordered, primitiveTransforms),
-        
-            // Get the list of transforms we'll use for Record types
-            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
-            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
-            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
-
-            // Get the list of transforms we'll use for List types
-            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
-            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
-            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
-
-            // Get the list of transforms we'll use for Table types
-            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
-            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
-            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
-
-            // Perform all of our transformations
-            allColumnTransforms = recordChanges & listChanges & tableChanges,
-            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimitives else Table.TransformColumns(changedPrimitives, allColumnTransforms, null, MissingField.Ignore),
-
-            // set final type
-            withType = Value.ReplaceType(changedRecordTypes, tableType)
-        in
-            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
-
+                    withType meta previousMeta,
     // If given a generic record type (no predefined fields), the original record is returned
     Record.ChangeType = (record as record, recordType as type) =>
         let
             // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
-            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fields =
+                try
+                    Type.RecordFields(recordType)
+                otherwise
+                    error "Record.ChangeType: failed to get record fields. Is this a record type?",
             fieldNames = Record.FieldNames(fields),
             fieldTable = Record.ToTable(fields),
-            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            optionalFields = Table.SelectRows(fieldTable, each[Value][Optional])[Name],
             requiredFields = List.Difference(fieldNames, optionalFields),
             // make sure all required fields exist
             withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
@@ -86,54 +121,75 @@
             // order the same as the record type
             reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
         in
-            if (List.IsEmpty(fieldNames)) then record else reorder,
-
+            if (List.IsEmpty(fieldNames)) then
+                record
+            else
+                reorder,
     List.ChangeType = (list as list, listType as type) =>
-        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
-        let
-            listItemType = Type.ListItem(listType),
-            transform = GetTransformByType(listItemType),
-            modifiedValues = List.Transform(list, transform),
-            typed = Value.ReplaceType(modifiedValues, listType)
-        in
-            typed,
-
+        if (not Type.Is(listType, type list)) then
+            error "type argument should be a list type"
+        else
+            let
+                listItemType = Type.ListItem(listType),
+                transform = GetTransformByType(listItemType),
+                modifiedValues = List.Transform(list, transform),
+                typed = Value.ReplaceType(modifiedValues, listType)
+            in
+                typed,
     // Returns a table type for the provided schema table
     Schema.ToTableType = (schema as table) as type =>
         let
-            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toList = List.Transform(schema[Type], (t) => [Type = t, Optional = false]),
             toRecord = Record.FromList(toList, schema[Name]),
             toType = Type.ForRecord(toRecord, false),
             previousMeta = Value.Metadata(schema)
         in
             type table (toType) meta previousMeta,
-
     // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
     // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
     GetTransformsForType = (_type as type) as list =>
         let
-            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
-                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
-                            else error "GetTransformsForType: record or table type expected",
+            fieldsOrColumns =
+                if (Type.Is(_type, type record)) then
+                    Type.RecordFields(_type)
+                else if (Type.Is(_type, type table)) then
+                    Type.RecordFields(Type.TableRow(_type))
+                else
+                    error "GetTransformsForType: record or table type expected",
             toTable = Record.ToTable(fieldsOrColumns),
-            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformColumn = Table.AddColumn(
+                toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type
+            ),
             transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
         in
             transformMap,
-
     GetTransformByType = (type_in as type) as function =>
-        let _type = Type.NonNullable(type_in) in
-        if (Type.Is(_type, type number)) then Number.From
-        else if (Type.Is(_type, type text)) then Text.From
-        else if (Type.Is(_type, type date)) then Date.From
-        else if (Type.Is(_type, type datetime)) then DateTime.From
-        else if (Type.Is(_type, type duration)) then Duration.From
-        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
-        else if (Type.Is(_type, type logical)) then Logical.From
-        else if (Type.Is(_type, type time)) then Time.From
-        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
-        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
-        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
-        else (t) => t
+        let
+            _type = Type.NonNullable(type_in)
+        in
+            if (Type.Is(_type, type number)) then
+                Number.From
+            else if (Type.Is(_type, type text)) then
+                Text.From
+            else if (Type.Is(_type, type date)) then
+                Date.From
+            else if (Type.Is(_type, type datetime)) then
+                DateTime.From
+            else if (Type.Is(_type, type duration)) then
+                Duration.From
+            else if (Type.Is(_type, type datetimezone)) then
+                DateTimeZone.From
+            else if (Type.Is(_type, type logical)) then
+                Logical.From
+            else if (Type.Is(_type, type time)) then
+                Time.From
+            else if (Type.Is(_type, type record)) then
+                (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+            else if (Type.Is(_type, type table)) then
+                (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+            else if (Type.Is(_type, type list)) then
+                (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+            else
+                (t) => t
 in
     Table.ChangeType

--- a/samples/TripPin/8-Diagnostics/Table.GenerateByPage.pqm
+++ b/samples/TripPin/8-Diagnostics/Table.GenerateByPage.pqm
@@ -1,21 +1,24 @@
 ﻿(getNextPage as function) as table =>
-    let        
+    let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+            // get the first page of data
+            () => getNextPage(null),
+            // stop when the function returns null
+            (lastPage) => lastPage <> null,
+            // pass the previous page to the next function call
+            (lastPage) => getNextPage(lastPage)
         ),
         // concatenate the pages together
         tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = tableOfPages{0} ?
     in
         // if we didn't get back any pages of data, return an empty table
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-		// check for empty first table
-		else if (Table.IsEmpty(firstRow[Column1])) then
-			firstRow[Column1]
+            // check for empty first table
+        else if (Table.IsEmpty(firstRow[Column1])) then
+            firstRow[Column1]
         else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),

--- a/samples/TripPin/8-Diagnostics/Table.ToNavigationTable.pqm
+++ b/samples/TripPin/8-Diagnostics/Table.ToNavigationTable.pqm
@@ -9,12 +9,11 @@
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)

--- a/samples/TripPin/8-Diagnostics/TripPin.pq
+++ b/samples/TripPin/8-Diagnostics/TripPin.pq
@@ -12,28 +12,25 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin Diagnostics", "TripPin Diagnostics" }
+    ButtonText = {"TripPin Diagnostics", "TripPin Diagnostics"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
 // Define our top level table types
-AirlinesType = type table [ AirlineCode = text, Name = text ];
+AirlinesType = type table [AirlineCode = text, Name = text];
 
-AirportsType = type table [
-    Name = text,
-    IataCode = text,
-    Location = LocationType
-];
+AirportsType = type table [Name = text, IataCode = text, Location = LocationType];
 
 PeopleType = type table [
     UserName = text,
@@ -46,46 +43,28 @@ PeopleType = type table [
 ];
 
 // remaining structured types
-LocationType = type [
-    Address = text,
-    City = CityType,
-    Loc = LocType
-];
+LocationType = type [Address = text, City = CityType, Loc = LocType];
 
-CityType = type [
-    CountryRegion = text,
-    Name = text,
-    Region = text
-];
+CityType = type [CountryRegion = text, Name = text, Region = text];
 
-LocType = type [
-    #"type" = text,
-    coordinates = {number},
-    crs = CrsType
-];
+LocType = type [#"type" = text, coordinates = {number}, crs = CrsType];
 
-CrsType = type [
-    #"type" = text,
-    properties = record
-];
+CrsType = type [#"type" = text, properties = record];
 
-SchemaTable = #table({"Entity", "Type"}, {
-    {"Airlines", AirlinesType },    
-    {"Airports", AirportsType },
-    {"People", PeopleType}    
-});
-        
+SchemaTable = #table(
+    {"Entity", "Type"}, {{"Airlines", AirlinesType}, {"Airports", AirportsType}, {"People", PeopleType}}
+);
+
 GetSchemaForEntity = (entity as text) as type =>
-    try 
-        SchemaTable{[Entity=entity]}[Type]
+    try
+        SchemaTable{[Entity = entity]}[Type]
     otherwise
         let
             message = Text.Format("Couldn't find entity: '#{0}'", {entity})
         in
             Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
 
-
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -94,8 +73,8 @@ TripPinNavTable = (url as text) as table =>
         entities = Table.SelectColumns(SchemaTable, {"Entity"}),
         rename = Table.RenameColumns(entities, {{"Entity", "Name"}}),
         // Add Data as a calculated column
-        //withData = Table.AddColumn(rename, "Data", each Diagnostics.LogFailure("Error in GetEntity", () => GetEntity(url, "DoesNotExist")), type table),
-        //withData = Table.AddColumn(rename, "Data", each GetEntity(url, "DoesNotExist"), type table),
+        // withData = Table.AddColumn(rename, "Data", each Diagnostics.LogFailure("Error in GetEntity", () => GetEntity(url, "DoesNotExist")), type table),
+        // withData = Table.AddColumn(rename, "Data", each GetEntity(url, "DoesNotExist"), type table),
         withData = Table.AddColumn(rename, "Data", each GetEntity(url, [Name]), type table),
         // Add ItemKind and ItemName as fixed text values
         withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
@@ -111,12 +90,12 @@ TripPin.Feed = (url as text, optional schema as type) as table =>
     let
         _url = Diagnostics.LogValue("Accessing url", url),
         _schema = Diagnostics.LogValue("Schema type", schema),
-        //result = GetAllPagesByNextLink(url, schema)
+        // result = GetAllPagesByNextLink(url, schema)
         result = GetAllPagesByNextLink(_url, _schema)
     in
         result;
 
-GetEntity = (url as text, entity as text) as table => 
+GetEntity = (url as text, entity as text) as table =>
     let
         fullUrl = Uri.Combine(url, entity),
         schema = GetSchemaForEntity(entity),
@@ -127,16 +106,17 @@ GetEntity = (url as text, entity as text) as table =>
 
 GetPage = (url as text, optional schema as type) as table =>
     let
-        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        response = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         body = Json.Document(response),
         nextLink = GetNextLink(body),
-        
         // If we have no schema, use Table.FromRecords() instead
         // (and hope that our results all have the same fields).
         // If we have a schema, expand the record using its field names
         data =
             if (schema = null) then
-                Diagnostics.LogFailure("Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value]))
+                Diagnostics.LogFailure(
+                    "Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value])
+                )
             else
                 let
                     // convert the list of records into a table (single column of records)
@@ -152,28 +132,28 @@ GetPage = (url as text, optional schema as type) as table =>
 // After every page, we check the "NextLink" record on the metadata of the previous request.
 // Table.GenerateByPage will keep asking for more pages until we return null.
 GetAllPagesByNextLink = (url as text, optional schema as type) as table =>
-    Table.GenerateByPage((previous) => 
-        let
-            // if previous is null, then this is our first page of data
-            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
-            // if NextLink was set to null by the previous call, we know we have no more data
-            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
-        in
-            page
+    Table.GenerateByPage(
+        (previous) =>
+            let
+                // if previous is null, then this is our first page of data
+                nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+                // if NextLink was set to null by the previous call, we know we have no more data
+                page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+            in
+                page
     );
 
 // In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
 // We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
 GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
 
-// 
+//
 // Load common library functions
-// 
+//
 // TEMPORARY WORKAROUND until we're able to reference other M modules
 Extension.LoadFunction = (name as text) =>
     let
-        binary = Extension.Contents(name),
-        asText = Text.FromBinary(binary)
+        binary = Extension.Contents(name), asText = Text.FromBinary(binary)
     in
         Expression.Evaluate(asText, #shared);
 
@@ -183,5 +163,6 @@ Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");
 
 // Diagnostics module contains multiple functions. We can take the ones we need.
 Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+
 Diagnostics.LogValue = Diagnostics[LogValue];
 Diagnostics.LogFailure = Diagnostics[LogFailure];

--- a/samples/TripPin/8-Diagnostics/TripPin.query.pq
+++ b/samples/TripPin/8-Diagnostics/TripPin.query.pq
@@ -1,205 +1,253 @@
 ﻿section TripPinUnitTests;
 
-shared TripPin.UnitTest =
-[
+shared TripPin.UnitTest = [
     // Put any common variables here if you only want them to be evaluated once
     RootTable = TripPin.Contents(),
-    Airlines = RootTable{[Name="Airlines"]}[Data],
-    Airports = RootTable{[Name="Airports"]}[Data],
-    People = RootTable{[Name="People"]}[Data],
-
+    Airlines = RootTable{[Name = "Airlines"]}[Data],
+    Airports = RootTable{[Name = "Airports"]}[Data],
+    People = RootTable{[Name = "People"]}[Data],
     // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
     // <Expected Value> and <Actual Value> can be a literal or let statement
-    facts =
-    {
+    facts = {
         Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
         Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
         Fact("We have People data?", true, not Table.IsEmpty(People)),
-        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
-        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
-        Fact("Airline table has the right fields",
-            {"AirlineCode","Name"},
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),
+        Fact(
+            "Airline table has the right fields",
+            {"AirlineCode", "Name"},
             Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
         ),
         Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails])))
     },
-
     report = Facts.Summarize(facts)
 ][report];
 
-/// COMMON UNIT TESTING CODE 
+/// COMMON UNIT TESTING CODE
 Fact = (_subject as text, _expected, _actual) as record =>
-[   expected = try _expected,
-    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
-    actual = try _actual,
-    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
-    attempt = try safeExpected = safeActual,
-    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
-    resultOp = if result = "Success ✓" then " = " else " <> ",
-    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
-    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
-    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
-    fact =
-    [   Result = result &" "& addendumEvalAttempt,
-        Notes =_subject,
-        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
-    ]
-][fact];
+    [
+        expected = try _expected,
+        safeExpected = if expected[HasError] then "Expected : " & @ValueToText(expected[Error]) else expected[Value],
+        actual = try _actual,
+        safeActual = if actual[HasError] then "Actual : " & @ValueToText(actual[Error]) else actual[Value],
+        attempt = try safeExpected = safeActual,
+        result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+        resultOp = if result = "Success ✓" then " = " else " <> ",
+        addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+        addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+        addendumEvalActual = try @ValueToText(safeActual) otherwise "...",
+        fact = [
+            Result = result & " " & addendumEvalAttempt,
+            Notes = _subject,
+            Details = " (" & addendumEvalExpected & resultOp & addendumEvalActual & ")"
+        ]
+    ][fact];
 
-Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject, _{0}, _{1}));
 
 Facts.Summarize = (_facts as list) as table =>
-[   Fact.CountSuccesses = (count, i) =>
-    [   result = try i[Result],
-        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
-    ][sum],
-    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
-    total = List.Count(_facts),
-    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
-    result = if passed = total then "Success" else "⛔",
-    rate = Number.IntegerDivide(100*passed, total),
-    header =
-    [   Result = result,
-        Notes = Text.Format(format, {passed, total-passed}),
-        Details = Text.Format("#{0}% success rate", {rate})
-    ],
-    report = Table.FromRecords(List.Combine({{header},_facts}))
-][report];
+    [
+        Fact.CountSuccesses = (count, i) =>
+            [
+                result = try i[Result],
+                sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+            ][sum],
+        passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+        total = List.Count(_facts),
+        format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+        result = if passed = total then "Success" else "⛔",
+        rate = Number.IntegerDivide(100 * passed, total),
+        header = [
+            Result = result,
+            Notes = Text.Format(format, {passed, total - passed}),
+            Details = Text.Format("#{0}% success rate", {rate})
+        ],
+        report = Table.FromRecords(List.Combine({{header}, _facts}))
+    ][report];
 
 ValueToText = (value, optional depth) =>
     let
-        List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-        Serialize.Function =    (x) => _serialize_function_param_type(
-                                          Type.FunctionParameters(Value.Type(x)),
-                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                       " as " &
-                                       _serialize_function_return_type(Value.Type(x)) &
-                                       " => (...) ",
-
-        Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-        Serialize.Record =      (x) => "[ " &
-                                       List.TransformAndCombine(
-                                            Record.FieldNames(x), 
-                                            (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                            ", ") &
-                                       " ] ",
-
-        Serialize.Table =       (x) => "#table( type " &
-                                        _serialize_table_type(Value.Type(x)) &
-                                        ", " &
-                                        Serialize(Table.ToRows(x)) &
-                                        ") ",
-                                    
-        Serialize.Identifier =  Expression.Identifier,
-
-        Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                    let
-                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                    in
-                                
-                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                        if x = type any then "any" else
-                                        let base = Type.NonNullable(x) in
-                                          (if Type.IsNullable(x) then "nullable " else "") &       
-                                          (if base = type anynonnull then "anynonnull" else                
-                                          if base = type binary then "binary" else                
-                                          if base = type date   then "date"   else
-                                          if base = type datetime then "datetime" else
-                                          if base = type datetimezone then "datetimezone" else
-                                          if base = type duration then "duration" else
-                                          if base = type logical then "logical" else
-                                          if base = type none then "none" else
-                                          if base = type null then "null" else
-                                          if base = type number then "number" else
-                                          if base = type text then "text" else 
-                                          if base = type time then "time" else 
-                                          if base = type type then "type" else 
-                                      
-                                          /* Abstract types: */
-                                          if base = type function then "function" else
-                                          if base = type table then "table" else
-                                          if base = type record then "record" else
-                                          if base = type list then "list" else
-                                      
-                                          "any /*Actually unknown type*/"),
-
-        _serialize_table_type =     (x) => 
-                                           let 
-                                             schema = Type.TableSchema(x)
-                                           in
-                                             "table " &
-                                             (if Table.IsEmpty(schema) then "" else 
-                                                 "[" & List.TransformAndCombine(
-                                                     Table.ToRecords(Table.Sort(schema,"Position")),
-                                                     each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                     ", ") &
-                                                 "] "),
-
-        _serialize_record_type =    (x) => 
-                                            let flds = Type.RecordFields(x)
-                                            in
-                                                if Record.FieldCount(flds)=0 then "record" else
-                                                    "[" & List.TransformAndCombine(
-                                                        Record.FieldNames(flds),
-                                                        (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                        ", ") & 
-                                                    (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                    "]",
-
-        _serialize_function_type =  (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(x),
-                                              Type.FunctionRequiredParameters(x) ) &
-                                            " as " &
-                                            _serialize_function_return_type(x),
-    
-        _serialize_function_param_type = (t,n) => 
-                                let
-                                    funsig = Table.ToRecords(
-                                        Table.TransformColumns(
-                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                            { "isOptional", (x)=> x>n } ) )
-                                in
-                                    "(" & 
-                                    List.TransformAndCombine(
-                                        funsig,
-                                        (item)=>
-                                            (if item[isOptional] then "optional " else "") &
-                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                        ", ") &
-                                     ")",
-
-        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-        Serialize = (x) as text => 
-                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                           if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                           if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                           if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                           "[#_unable_to_serialize_#]"                     
+        List.TransformAndCombine = (list, transform, separator) =>
+            Text.Combine(List.Transform(list, transform), separator),
+        Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+        Serialize.Function = (x) =>
+            _serialize_function_param_type(
+                Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+            )
+                & " as "
+                & _serialize_function_return_type(Value.Type(x))
+                & " => (...) ",
+        Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+        Serialize.Record = (x) =>
+            "[ "
+                & List.TransformAndCombine(
+                    Record.FieldNames(x),
+                    (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                    ", "
+                )
+                & " ] ",
+        Serialize.Table = (x) =>
+            "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+        Serialize.Identifier = Expression.Identifier,
+        Serialize.Type = (x) => "type " & _serialize_typename(x),
+        _serialize_typename = (x, optional funtype as logical) =>
+            // Optional parameter: Is this being used as part of a function signature?
+            let
+                isFunctionType = (x as type) =>
+                    try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                isTableType = (x as type) => try if Type.TableSchema(x) is table then true else false otherwise false,
+                isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false
+            otherwise
+                false,
+                isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+            in
+                if funtype = null and isTableType(x) then
+                    _serialize_table_type(x)
+                else if funtype = null and isListType(x) then
+                    "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                else if funtype = null and isFunctionType(x) then
+                    "function " & _serialize_function_type(x)
+                else if funtype = null and isRecordType(x) then
+                    _serialize_record_type(x)
+                else if x = type any then
+                    "any"
+                else
+                    let
+                        base = Type.NonNullable(x)
+                    in
+                        (if Type.IsNullable(x) then "nullable " else "")
+                            & (
+                                if base = type anynonnull then
+                                    "anynonnull"
+                                else if base = type binary then
+                                    "binary"
+                                else if base = type date then
+                                    "date"
+                                else if base = type datetime then
+                                    "datetime"
+                                else if base = type datetimezone then
+                                    "datetimezone"
+                                else if base = type duration then
+                                    "duration"
+                                else if base = type logical then
+                                    "logical"
+                                else if base = type none then
+                                    "none"
+                                else if base = type null then
+                                    "null"
+                                else if base = type number then
+                                    "number"
+                                else if base = type text then
+                                    "text"
+                                else if base = type time then
+                                    "time"
+                                else if base = type type then
+                                    "type"
+                                else
+                                // Abstract types
+                                if base = type function then
+                                    "function"
+                                else if base = type table then
+                                    "table"
+                                else if base = type record then
+                                    "record"
+                                else if base = type list then
+                                    "list"
+                                else
+                                    "any /*Actually unknown type*/"
+                            ),
+        _serialize_table_type = (x) =>
+            let
+                schema = Type.TableSchema(x)
+            in
+                "table "
+                    & (
+                        if Table.IsEmpty(schema) then
+                            ""
+                        else
+                            "["
+                                & List.TransformAndCombine(
+                                    Table.ToRecords(Table.Sort(schema, "Position")),
+                                    each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                    ", "
+                                )
+                                & "] "
+                    ),
+        _serialize_record_type = (x) =>
+            let
+                flds = Type.RecordFields(x)
+            in
+                if Record.FieldCount(flds) = 0 then
+                    "record"
+                else
+                    "["
+                        & List.TransformAndCombine(
+                            Record.FieldNames(flds),
+                            (item) =>
+                                Serialize.Identifier(item) & "=" & _serialize_typename(
+                                    Record.Field(flds, item)[Type]
+                                ),
+                            ", "
+                        )
+                        & (if Type.IsOpenRecord(x) then ", ..." else "")
+                        & "]",
+        _serialize_function_type = (x) =>
+            _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                & " as "
+                & _serialize_function_return_type(x),
+        _serialize_function_param_type = (t, n) =>
+            let
+                funsig = Table.ToRecords(
+                    Table.TransformColumns(
+                        Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                    )
+                )
+            in
+                "("
+                    & List.TransformAndCombine(
+                        funsig,
+                        (item) =>
+                            (if item[isOptional] then "optional " else "")
+                                & Serialize.Identifier(item[Name])
+                                & " as "
+                                & _serialize_typename(item[Value], true),
+                        ", "
+                    )
+                    & ")",
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+        Serialize = (x) as text =>
+            if x is binary then
+                try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+            else if x is date then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetime then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetimezone then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is duration then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is function then
+                try Serialize.Function(x) otherwise "null /*serialize failed*/"
+            else if x is list then
+                try Serialize.List(x) otherwise "null /*serialize failed*/"
+            else if x is logical then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is null then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is number then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is record then
+                try Serialize.Record(x) otherwise "null /*serialize failed*/"
+            else if x is table then
+                try Serialize.Table(x) otherwise "null /*serialize failed*/"
+            else if x is text then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is time then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is type then
+                try Serialize.Type(x) otherwise "null /*serialize failed*/"
+            else
+                "[#_unable_to_serialize_#]"
     in
         try Serialize(value) otherwise "<serialization failed>";

--- a/samples/TripPin/9-TestConnection/Diagnostics.pqm
+++ b/samples/TripPin/9-TestConnection/Diagnostics.pqm
@@ -1,161 +1,219 @@
 ﻿let
-    Diagnostics.LogValue = (prefix, value, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value, delayed),
-    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogValue = (prefix, value, optional delayed) =>
+        Diagnostics.Trace(
+            TraceLevel.Information,
+            prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"),
+            value,
+            delayed
+        ),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) =>
+        Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),
     Diagnostics.LogFailure = (text, function) =>
         let
             result = try function()
         in
-            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
-
+            if result[HasError] then
+                Diagnostics.LogValue2(text, result[Error], () => error result[Error], true)
+            else
+                result[Value],
     Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
         Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
-
     Diagnostics.WrapHandlers = (handlers as record) as record =>
         Record.FromList(
             List.Transform(
                 Record.FieldNames(handlers),
-                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
-            Record.FieldNames(handlers)),
-
+                (h) =>
+                    Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))
+            ),
+            Record.FieldNames(handlers)
+        ),
     Diagnostics.ValueToText = (value) =>
         let
-            List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-            Serialize.Function =    (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(Value.Type(x)),
-                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                           " as " &
-                                           _serialize_function_return_type(Value.Type(x)) &
-                                           " => (...) ",
-
-            Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-            Serialize.Record =      (x) => "[ " &
-                                           List.TransformAndCombine(
-                                                Record.FieldNames(x), 
-                                                (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                                ", ") &
-                                           " ] ",
-
-            Serialize.Table =       (x) => "#table( type " &
-                                            _serialize_table_type(Value.Type(x)) &
-                                            ", " &
-                                            Serialize(Table.ToRows(x)) &
-                                            ") ",
-                                    
-            Serialize.Identifier =  Expression.Identifier,
-
-            Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                        let
-                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                        in
-                                
-                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                            if x = type any then "any" else
-                                            let base = Type.NonNullable(x) in
-                                              (if Type.IsNullable(x) then "nullable " else "") &       
-                                              (if base = type anynonnull then "anynonnull" else                
-                                              if base = type binary then "binary" else                
-                                              if base = type date   then "date"   else
-                                              if base = type datetime then "datetime" else
-                                              if base = type datetimezone then "datetimezone" else
-                                              if base = type duration then "duration" else
-                                              if base = type logical then "logical" else
-                                              if base = type none then "none" else
-                                              if base = type null then "null" else
-                                              if base = type number then "number" else
-                                              if base = type text then "text" else 
-                                              if base = type time then "time" else 
-                                              if base = type type then "type" else 
-                                      
-                                              /* Abstract types: */
-                                              if base = type function then "function" else
-                                              if base = type table then "table" else
-                                              if base = type record then "record" else
-                                              if base = type list then "list" else
-                                      
-                                              "any /*Actually unknown type*/"),
-
-            _serialize_table_type =     (x) => 
-                                               let 
-                                                 schema = Type.TableSchema(x)
-                                               in
-                                                 "table " &
-                                                 (if Table.IsEmpty(schema) then "" else 
-                                                     "[" & List.TransformAndCombine(
-                                                         Table.ToRecords(Table.Sort(schema,"Position")),
-                                                         each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                         ", ") &
-                                                     "] "),
-
-            _serialize_record_type =    (x) => 
-                                                let flds = Type.RecordFields(x)
-                                                in
-                                                    if Record.FieldCount(flds)=0 then "record" else
-                                                        "[" & List.TransformAndCombine(
-                                                            Record.FieldNames(flds),
-                                                            (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                            ", ") & 
-                                                        (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                        "]",
-
-            _serialize_function_type =  (x) => _serialize_function_param_type(
-                                                  Type.FunctionParameters(x),
-                                                  Type.FunctionRequiredParameters(x) ) &
-                                                " as " &
-                                                _serialize_function_return_type(x),
-    
-            _serialize_function_param_type = (t,n) => 
-                                    let
-                                        funsig = Table.ToRecords(
-                                            Table.TransformColumns(
-                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                                { "isOptional", (x)=> x>n } ) )
-                                    in
-                                        "(" & 
-                                        List.TransformAndCombine(
-                                            funsig,
-                                            (item)=>
-                                                (if item[isOptional] then "optional " else "") &
-                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                            ", ") &
-                                         ")",
-
-            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-            Serialize = (x) as text => 
-                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                               if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                               if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                               if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                               "[#_unable_to_serialize_#]"                     
+            List.TransformAndCombine = (list, transform, separator) =>
+                Text.Combine(List.Transform(list, transform), separator),
+            Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+            Serialize.Function = (x) =>
+                _serialize_function_param_type(
+                    Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+                )
+                    & " as "
+                    & _serialize_function_return_type(Value.Type(x))
+                    & " => (...) ",
+            Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+            Serialize.Record = (x) =>
+                "[ "
+                    & List.TransformAndCombine(
+                        Record.FieldNames(x),
+                        (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                        ", "
+                    )
+                    & " ] ",
+            Serialize.Table = (x) =>
+                "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+            Serialize.Identifier = Expression.Identifier,
+            Serialize.Type = (x) => "type " & _serialize_typename(x),
+            _serialize_typename = (x, optional funtype as logical) =>
+                // Optional parameter: Is this being used as part of a function signature?
+                let
+                    isFunctionType = (x as type) =>
+                        try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                    isTableType = (x as type) =>
+                        try if Type.TableSchema(x) is table then true else false otherwise false,
+                    isRecordType = (x as type) =>
+                        try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                    isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                in
+                    if funtype = null and isTableType(x) then
+                        _serialize_table_type(x)
+                    else if funtype = null and isListType(x) then
+                        "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                    else if funtype = null and isFunctionType(x) then
+                        "function " & _serialize_function_type(x)
+                    else if funtype = null and isRecordType(x) then
+                        _serialize_record_type(x)
+                    else if x = type any then
+                        "any"
+                    else
+                        let
+                            base = Type.NonNullable(x)
+                        in
+                            (if Type.IsNullable(x) then "nullable " else "")
+                                & (
+                                    if base = type anynonnull then
+                                        "anynonnull"
+                                    else if base = type binary then
+                                        "binary"
+                                    else if base = type date then
+                                        "date"
+                                    else if base = type datetime then
+                                        "datetime"
+                                    else if base = type datetimezone then
+                                        "datetimezone"
+                                    else if base = type duration then
+                                        "duration"
+                                    else if base = type logical then
+                                        "logical"
+                                    else if base = type none then
+                                        "none"
+                                    else if base = type null then
+                                        "null"
+                                    else if base = type number then
+                                        "number"
+                                    else if base = type text then
+                                        "text"
+                                    else if base = type time then
+                                        "time"
+                                    else if base = type type then
+                                        "type"
+                                    else
+                                    // Abstract types
+                                    if base = type function then
+                                        "function"
+                                    else if base = type table then
+                                        "table"
+                                    else if base = type record then
+                                        "record"
+                                    else if base = type list then
+                                        "list"
+                                    else
+                                        "any /*Actually unknown type*/"
+                                ),
+            _serialize_table_type = (x) =>
+                let
+                    schema = Type.TableSchema(x)
+                in
+                    "table "
+                        & (
+                            if Table.IsEmpty(schema) then
+                                ""
+                            else
+                                "["
+                                    & List.TransformAndCombine(
+                                        Table.ToRecords(Table.Sort(schema, "Position")),
+                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                        ", "
+                                    )
+                                    & "] "
+                        ),
+            _serialize_record_type = (x) =>
+                let
+                    flds = Type.RecordFields(x)
+                in
+                    if Record.FieldCount(flds) = 0 then
+                        "record"
+                    else
+                        "["
+                            & List.TransformAndCombine(
+                                Record.FieldNames(flds),
+                                (item) =>
+                                    Serialize.Identifier(item)
+                                        & "="
+                                        & _serialize_typename(Record.Field(flds, item)[Type]),
+                                ", "
+                            )
+                            & (if Type.IsOpenRecord(x) then ", ..." else "")
+                            & "]",
+            _serialize_function_type = (x) =>
+                _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                    & " as "
+                    & _serialize_function_return_type(x),
+            _serialize_function_param_type = (t, n) =>
+                let
+                    funsig = Table.ToRecords(
+                        Table.TransformColumns(
+                            Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                        )
+                    )
+                in
+                    "("
+                        & List.TransformAndCombine(
+                            funsig,
+                            (item) =>
+                                (if item[isOptional] then "optional " else "")
+                                    & Serialize.Identifier(item[Name])
+                                    & " as "
+                                    & _serialize_typename(item[Value], true),
+                            ", "
+                        )
+                        & ")",
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+            Serialize = (x) as text =>
+                if x is binary then
+                    try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+                else if x is date then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetime then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is datetimezone then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is duration then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is function then
+                    try Serialize.Function(x) otherwise "null /*serialize failed*/"
+                else if x is list then
+                    try Serialize.List(x) otherwise "null /*serialize failed*/"
+                else if x is logical then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is null then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is number then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is record then
+                    try Serialize.Record(x) otherwise "null /*serialize failed*/"
+                else if x is table then
+                    try Serialize.Table(x) otherwise "null /*serialize failed*/"
+                else if x is text then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is time then
+                    try Expression.Constant(x) otherwise "null /*serialize failed*/"
+                else if x is type then
+                    try Serialize.Type(x) otherwise "null /*serialize failed*/"
+                else
+                    "[#_unable_to_serialize_#]"
         in
             try Serialize(value) otherwise "<serialization failed>"
 in
-    [ 
+    [
         LogValue = Diagnostics.LogValue,
         LogValue2 = Diagnostics.LogValue2,
         LogFailure = Diagnostics.LogFailure,

--- a/samples/TripPin/9-TestConnection/Table.ChangeType.pqm
+++ b/samples/TripPin/9-TestConnection/Table.ChangeType.pqm
@@ -2,79 +2,114 @@
     // table should be an actual Table.Type, or a List.Type of Records
     Table.ChangeType = (table, tableType as type) as nullable table =>
         // we only operate on table types
-        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        if (not Type.Is(tableType, type table)) then
+            error "type argument should be a table type"
+        else
         // if we have a null value, just return it
-        if (table = null) then table else
-        let
-            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
-            columnsAsTable = Record.ToTable(columnsForType),
-            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
-            previousMeta = Value.Metadata(tableType),
-
-            // make sure we have a table
-            parameterType = Value.Type(table),
-            _table =
-                if (Type.Is(parameterType, type table)) then table
-                else if (Type.Is(parameterType, type list)) then
-                    let
-                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
-                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
-                        result =
-                            // if the member is a record (as expected), then expand it. 
+        if (table = null) then
+            table
+        else
+            let
+                columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+                columnsAsTable = Record.ToTable(columnsForType),
+                schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+                previousMeta = Value.Metadata(tableType),
+                // make sure we have a table
+                parameterType = Value.Type(table),
+                _table =
+                    if (Type.Is(parameterType, type table)) then
+                        table
+                    else if (Type.Is(parameterType, type list)) then
+                        let
+                            asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                            firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                            result =
+                            // if the member is a record (as expected), then expand it.
                             if (Type.Is(firstValueType, type record)) then
                                 Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
                             else
-                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
-                    in
-                        if (List.IsEmpty(table)) then
-                            #table({"a"}, {})
-                        else result
+                                error
+                                    Error.Record(
+                                        "Error.Parameter",
+                                        "table argument is a list, but not a list of records",
+                                        [
+                                            ValueType = firstValueType
+                                        ]
+                                    )
+                        in
+                            if (List.IsEmpty(table)) then
+                                #table({"a"}, {})
+                            else
+                                result
+                    else
+                        error
+                            Error.Record(
+                                "Error.Parameter",
+                                "table argument should be a table or list of records",
+                                [
+                                    ValueType = parameterType
+                                ]
+                            ),
+                reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+                // process primitive values - this will call Table.TransformColumnTypes
+                map = (t) =>
+                    if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any
+                    then
+                        null
+                    else
+                        t,
+                mapped = Table.TransformColumns(schema, {"Type", map}),
+                omitted = Table.SelectRows(mapped, each [Type] <> null),
+                existingColumns = Table.ColumnNames(reordered),
+                removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+                primitiveTransforms = Table.ToRows(removeMissing),
+                changedPrimitives = Table.TransformColumnTypes(reordered, primitiveTransforms),
+                // Get the list of transforms we'll use for Record types
+                recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+                recordTypeTransformations = Table.AddColumn(
+                    recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function
+                ),
+                recordChanges = Table.ToRows(
+                    Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})
+                ),
+                // Get the list of transforms we'll use for List types
+                listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+                listTransforms = Table.AddColumn(
+                    listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type
+                ),
+                listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+                // Get the list of transforms we'll use for Table types
+                tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+                tableTransforms = Table.AddColumn(
+                    tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type
+                ),
+                tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+                // Perform all of our transformations
+                allColumnTransforms = recordChanges & listChanges & tableChanges,
+                changedRecordTypes =
+                    if (List.IsEmpty(allColumnTransforms)) then
+                        changedPrimitives
+                    else
+                        Table.TransformColumns(changedPrimitives, allColumnTransforms, null, MissingField.Ignore),
+                // set final type
+                withType = Value.ReplaceType(changedRecordTypes, tableType)
+            in
+                if (List.IsEmpty(Record.FieldNames(columnsForType))) then
+                    table
                 else
-                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
-
-            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
-
-            // process primitive values - this will call Table.TransformColumnTypes
-            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
-            mapped = Table.TransformColumns(schema, {"Type", map}),
-            omitted = Table.SelectRows(mapped, each [Type] <> null),
-            existingColumns = Table.ColumnNames(reordered),
-            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
-            primitiveTransforms = Table.ToRows(removeMissing),
-            changedPrimitives = Table.TransformColumnTypes(reordered, primitiveTransforms),
-        
-            // Get the list of transforms we'll use for Record types
-            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
-            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
-            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
-
-            // Get the list of transforms we'll use for List types
-            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
-            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
-            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
-
-            // Get the list of transforms we'll use for Table types
-            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
-            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
-            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
-
-            // Perform all of our transformations
-            allColumnTransforms = recordChanges & listChanges & tableChanges,
-            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimitives else Table.TransformColumns(changedPrimitives, allColumnTransforms, null, MissingField.Ignore),
-
-            // set final type
-            withType = Value.ReplaceType(changedRecordTypes, tableType)
-        in
-            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
-
+                    withType meta previousMeta,
     // If given a generic record type (no predefined fields), the original record is returned
     Record.ChangeType = (record as record, recordType as type) =>
         let
             // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
-            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fields =
+                try
+                    Type.RecordFields(recordType)
+                otherwise
+                    error "Record.ChangeType: failed to get record fields. Is this a record type?",
             fieldNames = Record.FieldNames(fields),
             fieldTable = Record.ToTable(fields),
-            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            optionalFields = Table.SelectRows(fieldTable, each[Value][Optional])[Name],
             requiredFields = List.Difference(fieldNames, optionalFields),
             // make sure all required fields exist
             withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
@@ -86,54 +121,75 @@
             // order the same as the record type
             reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
         in
-            if (List.IsEmpty(fieldNames)) then record else reorder,
-
+            if (List.IsEmpty(fieldNames)) then
+                record
+            else
+                reorder,
     List.ChangeType = (list as list, listType as type) =>
-        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
-        let
-            listItemType = Type.ListItem(listType),
-            transform = GetTransformByType(listItemType),
-            modifiedValues = List.Transform(list, transform),
-            typed = Value.ReplaceType(modifiedValues, listType)
-        in
-            typed,
-
+        if (not Type.Is(listType, type list)) then
+            error "type argument should be a list type"
+        else
+            let
+                listItemType = Type.ListItem(listType),
+                transform = GetTransformByType(listItemType),
+                modifiedValues = List.Transform(list, transform),
+                typed = Value.ReplaceType(modifiedValues, listType)
+            in
+                typed,
     // Returns a table type for the provided schema table
     Schema.ToTableType = (schema as table) as type =>
         let
-            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toList = List.Transform(schema[Type], (t) => [Type = t, Optional = false]),
             toRecord = Record.FromList(toList, schema[Name]),
             toType = Type.ForRecord(toRecord, false),
             previousMeta = Value.Metadata(schema)
         in
             type table (toType) meta previousMeta,
-
     // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
     // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
     GetTransformsForType = (_type as type) as list =>
         let
-            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
-                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
-                            else error "GetTransformsForType: record or table type expected",
+            fieldsOrColumns =
+                if (Type.Is(_type, type record)) then
+                    Type.RecordFields(_type)
+                else if (Type.Is(_type, type table)) then
+                    Type.RecordFields(Type.TableRow(_type))
+                else
+                    error "GetTransformsForType: record or table type expected",
             toTable = Record.ToTable(fieldsOrColumns),
-            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformColumn = Table.AddColumn(
+                toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type
+            ),
             transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
         in
             transformMap,
-
     GetTransformByType = (type_in as type) as function =>
-        let _type = Type.NonNullable(type_in) in
-        if (Type.Is(_type, type number)) then Number.From
-        else if (Type.Is(_type, type text)) then Text.From
-        else if (Type.Is(_type, type date)) then Date.From
-        else if (Type.Is(_type, type datetime)) then DateTime.From
-        else if (Type.Is(_type, type duration)) then Duration.From
-        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
-        else if (Type.Is(_type, type logical)) then Logical.From
-        else if (Type.Is(_type, type time)) then Time.From
-        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
-        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
-        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
-        else (t) => t
+        let
+            _type = Type.NonNullable(type_in)
+        in
+            if (Type.Is(_type, type number)) then
+                Number.From
+            else if (Type.Is(_type, type text)) then
+                Text.From
+            else if (Type.Is(_type, type date)) then
+                Date.From
+            else if (Type.Is(_type, type datetime)) then
+                DateTime.From
+            else if (Type.Is(_type, type duration)) then
+                Duration.From
+            else if (Type.Is(_type, type datetimezone)) then
+                DateTimeZone.From
+            else if (Type.Is(_type, type logical)) then
+                Logical.From
+            else if (Type.Is(_type, type time)) then
+                Time.From
+            else if (Type.Is(_type, type record)) then
+                (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+            else if (Type.Is(_type, type table)) then
+                (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+            else if (Type.Is(_type, type list)) then
+                (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+            else
+                (t) => t
 in
     Table.ChangeType

--- a/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -1,21 +1,24 @@
 ﻿(getNextPage as function) as table =>
-    let        
+    let
         listOfPages = List.Generate(
-            () => getNextPage(null),            // get the first page of data
-            (lastPage) => lastPage <> null,     // stop when the function returns null
-            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+            // get the first page of data
+            () => getNextPage(null),
+            // stop when the function returns null
+            (lastPage) => lastPage <> null,
+            // pass the previous page to the next function call
+            (lastPage) => getNextPage(lastPage)
         ),
         // concatenate the pages together
         tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
-        firstRow = tableOfPages{0}?
+        firstRow = tableOfPages{0} ?
     in
         // if we didn't get back any pages of data, return an empty table
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-		// check for empty first table
-		else if (Table.IsEmpty(firstRow[Column1])) then
-			firstRow[Column1]
+            // check for empty first table
+        else if (Table.IsEmpty(firstRow[Column1])) then
+            firstRow[Column1]
         else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),

--- a/samples/TripPin/9-TestConnection/Table.ToNavigationTable.pqm
+++ b/samples/TripPin/9-TestConnection/Table.ToNavigationTable.pqm
@@ -9,12 +9,11 @@
 ) as table =>
     let
         tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta [
+            NavigationTable.NameColumn = nameColumn,
             NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.ItemKindColumn = itemKindColumn,
+            Preview.DelayColumn = itemNameColumn,
             NavigationTable.IsLeafColumn = isLeafColumn
         ],
         navigationTable = Value.ReplaceType(table, newTableType)

--- a/samples/TripPin/9-TestConnection/TripPin.pq
+++ b/samples/TripPin/9-TestConnection/TripPin.pq
@@ -3,7 +3,7 @@
 // Data Source Kind description
 TripPin = [
     // TestConnection is required to enable the connector through the Gateway
-    TestConnection = (dataSourcePath) => { "TripPin.Contents" },
+    TestConnection = (dataSourcePath) => {"TripPin.Contents"},
     Authentication = [
         Anonymous = []
     ],
@@ -14,28 +14,25 @@ TripPin = [
 TripPin.Publish = [
     Beta = true,
     Category = "Other",
-    ButtonText = { "TripPin TestConnection", "TripPin TestConnection" }
+    ButtonText = {"TripPin TestConnection", "TripPin TestConnection"}
 ];
 
 //
 // Implementation
-// 
-
+//
 DefaultRequestHeaders = [
-    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
-    #"OData-MaxVersion" = "4.0"                             // we only support v4
+    // column name and values only
+    #"Accept" = "application/json;odata.metadata=minimal",
+    // we only support v4
+    #"OData-MaxVersion" = "4.0"
 ];
 
 BaseUrl = "http://services.odata.org/v4/TripPinService/";
 
 // Define our top level table types
-AirlinesType = type table [ AirlineCode = text, Name = text ];
+AirlinesType = type table [AirlineCode = text, Name = text];
 
-AirportsType = type table [
-    Name = text,
-    IataCode = text,
-    Location = LocationType
-];
+AirportsType = type table [Name = text, IataCode = text, Location = LocationType];
 
 PeopleType = type table [
     UserName = text,
@@ -48,46 +45,28 @@ PeopleType = type table [
 ];
 
 // remaining structured types
-LocationType = type [
-    Address = text,
-    City = CityType,
-    Loc = LocType
-];
+LocationType = type [Address = text, City = CityType, Loc = LocType];
 
-CityType = type [
-    CountryRegion = text,
-    Name = text,
-    Region = text
-];
+CityType = type [CountryRegion = text, Name = text, Region = text];
 
-LocType = type [
-    #"type" = text,
-    coordinates = {number},
-    crs = CrsType
-];
+LocType = type [#"type" = text, coordinates = {number}, crs = CrsType];
 
-CrsType = type [
-    #"type" = text,
-    properties = record
-];
+CrsType = type [#"type" = text, properties = record];
 
-SchemaTable = #table({"Entity", "Type"}, {
-    {"Airlines", AirlinesType },    
-    {"Airports", AirportsType },
-    {"People", PeopleType}    
-});
-        
+SchemaTable = #table(
+    {"Entity", "Type"}, {{"Airlines", AirlinesType}, {"Airports", AirportsType}, {"People", PeopleType}}
+);
+
 GetSchemaForEntity = (entity as text) as type =>
-    try 
-        SchemaTable{[Entity=entity]}[Type]
+    try
+        SchemaTable{[Entity = entity]}[Type]
     otherwise
         let
             message = Text.Format("Couldn't find entity: '#{0}'", {entity})
         in
             Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
 
-
-[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+[DataSource.Kind = "TripPin", Publish = "TripPin.Publish"]
 shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
 
 TripPinNavTable = (url as text) as table =>
@@ -96,8 +75,8 @@ TripPinNavTable = (url as text) as table =>
         entities = Table.SelectColumns(SchemaTable, {"Entity"}),
         rename = Table.RenameColumns(entities, {{"Entity", "Name"}}),
         // Add Data as a calculated column
-        //withData = Table.AddColumn(rename, "Data", each Diagnostics.LogFailure("Error in GetEntity", () => GetEntity(url, "DoesNotExist")), type table),
-        //withData = Table.AddColumn(rename, "Data", each GetEntity(url, "DoesNotExist"), type table),
+        // withData = Table.AddColumn(rename, "Data", each Diagnostics.LogFailure("Error in GetEntity", () => GetEntity(url, "DoesNotExist")), type table),
+        // withData = Table.AddColumn(rename, "Data", each GetEntity(url, "DoesNotExist"), type table),
         withData = Table.AddColumn(rename, "Data", each GetEntity(url, [Name]), type table),
         // Add ItemKind and ItemName as fixed text values
         withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
@@ -113,12 +92,12 @@ TripPin.Feed = (url as text, optional schema as type) as table =>
     let
         _url = Diagnostics.LogValue("Accessing url", url),
         _schema = Diagnostics.LogValue("Schema type", schema),
-        //result = GetAllPagesByNextLink(url, schema)
+        // result = GetAllPagesByNextLink(url, schema)
         result = GetAllPagesByNextLink(_url, _schema)
     in
         result;
 
-GetEntity = (url as text, entity as text) as table => 
+GetEntity = (url as text, entity as text) as table =>
     let
         fullUrl = Uri.Combine(url, entity),
         schema = GetSchemaForEntity(entity),
@@ -129,16 +108,17 @@ GetEntity = (url as text, entity as text) as table =>
 
 GetPage = (url as text, optional schema as type) as table =>
     let
-        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        response = Web.Contents(url, [Headers = DefaultRequestHeaders]),
         body = Json.Document(response),
         nextLink = GetNextLink(body),
-        
         // If we have no schema, use Table.FromRecords() instead
         // (and hope that our results all have the same fields).
         // If we have a schema, expand the record using its field names
         data =
             if (schema = null) then
-                Diagnostics.LogFailure("Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value]))
+                Diagnostics.LogFailure(
+                    "Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value])
+                )
             else
                 let
                     // convert the list of records into a table (single column of records)
@@ -154,28 +134,28 @@ GetPage = (url as text, optional schema as type) as table =>
 // After every page, we check the "NextLink" record on the metadata of the previous request.
 // Table.GenerateByPage will keep asking for more pages until we return null.
 GetAllPagesByNextLink = (url as text, optional schema as type) as table =>
-    Table.GenerateByPage((previous) => 
-        let
-            // if previous is null, then this is our first page of data
-            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
-            // if NextLink was set to null by the previous call, we know we have no more data
-            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
-        in
-            page
+    Table.GenerateByPage(
+        (previous) =>
+            let
+                // if previous is null, then this is our first page of data
+                nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+                // if NextLink was set to null by the previous call, we know we have no more data
+                page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+            in
+                page
     );
 
 // In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
 // We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
 GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
 
-// 
+//
 // Load common library functions
-// 
+//
 // TEMPORARY WORKAROUND until we're able to reference other M modules
 Extension.LoadFunction = (name as text) =>
     let
-        binary = Extension.Contents(name),
-        asText = Text.FromBinary(binary)
+        binary = Extension.Contents(name), asText = Text.FromBinary(binary)
     in
         Expression.Evaluate(asText, #shared);
 
@@ -185,5 +165,6 @@ Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");
 
 // Diagnostics module contains multiple functions. We can take the ones we need.
 Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+
 Diagnostics.LogValue = Diagnostics[LogValue];
 Diagnostics.LogFailure = Diagnostics[LogFailure];

--- a/samples/TripPin/9-TestConnection/TripPin.query.pq
+++ b/samples/TripPin/9-TestConnection/TripPin.query.pq
@@ -1,205 +1,253 @@
 ﻿section TripPinUnitTests;
 
-shared TripPin.UnitTest =
-[
+shared TripPin.UnitTest = [
     // Put any common variables here if you only want them to be evaluated once
     RootTable = TripPin.Contents(),
-    Airlines = RootTable{[Name="Airlines"]}[Data],
-    Airports = RootTable{[Name="Airports"]}[Data],
-    People = RootTable{[Name="People"]}[Data],
-
+    Airlines = RootTable{[Name = "Airlines"]}[Data],
+    Airports = RootTable{[Name = "Airports"]}[Data],
+    People = RootTable{[Name = "People"]}[Data],
     // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
     // <Expected Value> and <Actual Value> can be a literal or let statement
-    facts =
-    {
+    facts = {
         Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
         Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
         Fact("We have People data?", true, not Table.IsEmpty(People)),
-        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
-        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
-        Fact("Airline table has the right fields",
-            {"AirlineCode","Name"},
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),
+        Fact(
+            "Airline table has the right fields",
+            {"AirlineCode", "Name"},
             Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
         ),
         Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails])))
     },
-
     report = Facts.Summarize(facts)
 ][report];
 
-/// COMMON UNIT TESTING CODE 
+/// COMMON UNIT TESTING CODE
 Fact = (_subject as text, _expected, _actual) as record =>
-[   expected = try _expected,
-    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
-    actual = try _actual,
-    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
-    attempt = try safeExpected = safeActual,
-    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
-    resultOp = if result = "Success ✓" then " = " else " <> ",
-    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
-    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
-    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
-    fact =
-    [   Result = result &" "& addendumEvalAttempt,
-        Notes =_subject,
-        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
-    ]
-][fact];
+    [
+        expected = try _expected,
+        safeExpected = if expected[HasError] then "Expected : " & @ValueToText(expected[Error]) else expected[Value],
+        actual = try _actual,
+        safeActual = if actual[HasError] then "Actual : " & @ValueToText(actual[Error]) else actual[Value],
+        attempt = try safeExpected = safeActual,
+        result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+        resultOp = if result = "Success ✓" then " = " else " <> ",
+        addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+        addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+        addendumEvalActual = try @ValueToText(safeActual) otherwise "...",
+        fact = [
+            Result = result & " " & addendumEvalAttempt,
+            Notes = _subject,
+            Details = " (" & addendumEvalExpected & resultOp & addendumEvalActual & ")"
+        ]
+    ][fact];
 
-Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject, _{0}, _{1}));
 
 Facts.Summarize = (_facts as list) as table =>
-[   Fact.CountSuccesses = (count, i) =>
-    [   result = try i[Result],
-        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
-    ][sum],
-    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
-    total = List.Count(_facts),
-    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
-    result = if passed = total then "Success" else "⛔",
-    rate = Number.IntegerDivide(100*passed, total),
-    header =
-    [   Result = result,
-        Notes = Text.Format(format, {passed, total-passed}),
-        Details = Text.Format("#{0}% success rate", {rate})
-    ],
-    report = Table.FromRecords(List.Combine({{header},_facts}))
-][report];
+    [
+        Fact.CountSuccesses = (count, i) =>
+            [
+                result = try i[Result],
+                sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+            ][sum],
+        passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+        total = List.Count(_facts),
+        format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+        result = if passed = total then "Success" else "⛔",
+        rate = Number.IntegerDivide(100 * passed, total),
+        header = [
+            Result = result,
+            Notes = Text.Format(format, {passed, total - passed}),
+            Details = Text.Format("#{0}% success rate", {rate})
+        ],
+        report = Table.FromRecords(List.Combine({{header}, _facts}))
+    ][report];
 
 ValueToText = (value, optional depth) =>
     let
-        List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-        Serialize.Function =    (x) => _serialize_function_param_type(
-                                          Type.FunctionParameters(Value.Type(x)),
-                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                       " as " &
-                                       _serialize_function_return_type(Value.Type(x)) &
-                                       " => (...) ",
-
-        Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-        Serialize.Record =      (x) => "[ " &
-                                       List.TransformAndCombine(
-                                            Record.FieldNames(x), 
-                                            (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                            ", ") &
-                                       " ] ",
-
-        Serialize.Table =       (x) => "#table( type " &
-                                        _serialize_table_type(Value.Type(x)) &
-                                        ", " &
-                                        Serialize(Table.ToRows(x)) &
-                                        ") ",
-                                    
-        Serialize.Identifier =  Expression.Identifier,
-
-        Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                    let
-                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                    in
-                                
-                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                        if x = type any then "any" else
-                                        let base = Type.NonNullable(x) in
-                                          (if Type.IsNullable(x) then "nullable " else "") &       
-                                          (if base = type anynonnull then "anynonnull" else                
-                                          if base = type binary then "binary" else                
-                                          if base = type date   then "date"   else
-                                          if base = type datetime then "datetime" else
-                                          if base = type datetimezone then "datetimezone" else
-                                          if base = type duration then "duration" else
-                                          if base = type logical then "logical" else
-                                          if base = type none then "none" else
-                                          if base = type null then "null" else
-                                          if base = type number then "number" else
-                                          if base = type text then "text" else 
-                                          if base = type time then "time" else 
-                                          if base = type type then "type" else 
-                                      
-                                          /* Abstract types: */
-                                          if base = type function then "function" else
-                                          if base = type table then "table" else
-                                          if base = type record then "record" else
-                                          if base = type list then "list" else
-                                      
-                                          "any /*Actually unknown type*/"),
-
-        _serialize_table_type =     (x) => 
-                                           let 
-                                             schema = Type.TableSchema(x)
-                                           in
-                                             "table " &
-                                             (if Table.IsEmpty(schema) then "" else 
-                                                 "[" & List.TransformAndCombine(
-                                                     Table.ToRecords(Table.Sort(schema,"Position")),
-                                                     each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                     ", ") &
-                                                 "] "),
-
-        _serialize_record_type =    (x) => 
-                                            let flds = Type.RecordFields(x)
-                                            in
-                                                if Record.FieldCount(flds)=0 then "record" else
-                                                    "[" & List.TransformAndCombine(
-                                                        Record.FieldNames(flds),
-                                                        (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                        ", ") & 
-                                                    (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                    "]",
-
-        _serialize_function_type =  (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(x),
-                                              Type.FunctionRequiredParameters(x) ) &
-                                            " as " &
-                                            _serialize_function_return_type(x),
-    
-        _serialize_function_param_type = (t,n) => 
-                                let
-                                    funsig = Table.ToRecords(
-                                        Table.TransformColumns(
-                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                            { "isOptional", (x)=> x>n } ) )
-                                in
-                                    "(" & 
-                                    List.TransformAndCombine(
-                                        funsig,
-                                        (item)=>
-                                            (if item[isOptional] then "optional " else "") &
-                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                        ", ") &
-                                     ")",
-
-        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-        Serialize = (x) as text => 
-                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                           if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                           if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                           if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                           "[#_unable_to_serialize_#]"                     
+        List.TransformAndCombine = (list, transform, separator) =>
+            Text.Combine(List.Transform(list, transform), separator),
+        Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+        Serialize.Function = (x) =>
+            _serialize_function_param_type(
+                Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+            )
+                & " as "
+                & _serialize_function_return_type(Value.Type(x))
+                & " => (...) ",
+        Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+        Serialize.Record = (x) =>
+            "[ "
+                & List.TransformAndCombine(
+                    Record.FieldNames(x),
+                    (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                    ", "
+                )
+                & " ] ",
+        Serialize.Table = (x) =>
+            "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+        Serialize.Identifier = Expression.Identifier,
+        Serialize.Type = (x) => "type " & _serialize_typename(x),
+        _serialize_typename = (x, optional funtype as logical) =>
+            // Optional parameter: Is this being used as part of a function signature?
+            let
+                isFunctionType = (x as type) =>
+                    try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                isTableType = (x as type) => try if Type.TableSchema(x) is table then true else false otherwise false,
+                isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false
+            otherwise
+                false,
+                isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+            in
+                if funtype = null and isTableType(x) then
+                    _serialize_table_type(x)
+                else if funtype = null and isListType(x) then
+                    "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                else if funtype = null and isFunctionType(x) then
+                    "function " & _serialize_function_type(x)
+                else if funtype = null and isRecordType(x) then
+                    _serialize_record_type(x)
+                else if x = type any then
+                    "any"
+                else
+                    let
+                        base = Type.NonNullable(x)
+                    in
+                        (if Type.IsNullable(x) then "nullable " else "")
+                            & (
+                                if base = type anynonnull then
+                                    "anynonnull"
+                                else if base = type binary then
+                                    "binary"
+                                else if base = type date then
+                                    "date"
+                                else if base = type datetime then
+                                    "datetime"
+                                else if base = type datetimezone then
+                                    "datetimezone"
+                                else if base = type duration then
+                                    "duration"
+                                else if base = type logical then
+                                    "logical"
+                                else if base = type none then
+                                    "none"
+                                else if base = type null then
+                                    "null"
+                                else if base = type number then
+                                    "number"
+                                else if base = type text then
+                                    "text"
+                                else if base = type time then
+                                    "time"
+                                else if base = type type then
+                                    "type"
+                                else
+                                // Abstract types
+                                if base = type function then
+                                    "function"
+                                else if base = type table then
+                                    "table"
+                                else if base = type record then
+                                    "record"
+                                else if base = type list then
+                                    "list"
+                                else
+                                    "any /*Actually unknown type*/"
+                            ),
+        _serialize_table_type = (x) =>
+            let
+                schema = Type.TableSchema(x)
+            in
+                "table "
+                    & (
+                        if Table.IsEmpty(schema) then
+                            ""
+                        else
+                            "["
+                                & List.TransformAndCombine(
+                                    Table.ToRecords(Table.Sort(schema, "Position")),
+                                    each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                    ", "
+                                )
+                                & "] "
+                    ),
+        _serialize_record_type = (x) =>
+            let
+                flds = Type.RecordFields(x)
+            in
+                if Record.FieldCount(flds) = 0 then
+                    "record"
+                else
+                    "["
+                        & List.TransformAndCombine(
+                            Record.FieldNames(flds),
+                            (item) =>
+                                Serialize.Identifier(item) & "=" & _serialize_typename(
+                                    Record.Field(flds, item)[Type]
+                                ),
+                            ", "
+                        )
+                        & (if Type.IsOpenRecord(x) then ", ..." else "")
+                        & "]",
+        _serialize_function_type = (x) =>
+            _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                & " as "
+                & _serialize_function_return_type(x),
+        _serialize_function_param_type = (t, n) =>
+            let
+                funsig = Table.ToRecords(
+                    Table.TransformColumns(
+                        Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                    )
+                )
+            in
+                "("
+                    & List.TransformAndCombine(
+                        funsig,
+                        (item) =>
+                            (if item[isOptional] then "optional " else "")
+                                & Serialize.Identifier(item[Name])
+                                & " as "
+                                & _serialize_typename(item[Value], true),
+                        ", "
+                    )
+                    & ")",
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+        Serialize = (x) as text =>
+            if x is binary then
+                try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+            else if x is date then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetime then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetimezone then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is duration then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is function then
+                try Serialize.Function(x) otherwise "null /*serialize failed*/"
+            else if x is list then
+                try Serialize.List(x) otherwise "null /*serialize failed*/"
+            else if x is logical then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is null then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is number then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is record then
+                try Serialize.Record(x) otherwise "null /*serialize failed*/"
+            else if x is table then
+                try Serialize.Table(x) otherwise "null /*serialize failed*/"
+            else if x is text then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is time then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is type then
+                try Serialize.Type(x) otherwise "null /*serialize failed*/"
+            else
+                "[#_unable_to_serialize_#]"
     in
         try Serialize(value) otherwise "<serialization failed>";

--- a/samples/UnitTesting/UnitTesting.pq
+++ b/samples/UnitTesting/UnitTesting.pq
@@ -2,6 +2,4 @@
 
 shared UnitTesting.ReturnsABC = () => "ABC";
 shared UnitTesting.Returns123 = () => "123";
-shared UnitTesting.ReturnsTableWithFiveRows = () => Table.Repeat(#table({"a"},{{1}}), 5);
-
-
+shared UnitTesting.ReturnsTableWithFiveRows = () => Table.Repeat(#table({"a"}, {{1}}), 5);

--- a/samples/UnitTesting/UnitTesting.query.pq
+++ b/samples/UnitTesting/UnitTesting.query.pq
@@ -1,210 +1,248 @@
 ﻿section UnitTestingUnitTests;
 
-shared MyExtension.UnitTest =
-[
+shared MyExtension.UnitTest = [
     // Put any common variables here if you only want them to be evaluated once
-
     // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
     // <Expected Value> and <Actual Value> can be a literal or let statement
-    facts =
-    {        
-        Fact("Check that this function returns 'ABC'",  // name of the test
-             "ABC",                                     // expected value
-             UnitTesting.ReturnsABC()                   // expression to evaluate (let or single statement)
-        ),
-        Fact("Check that this function returns '123'",
-             "124",                                   
-             UnitTesting.Returns123()
-        ),
-        Fact("Result should contain 5 rows",
-            5,
-            Table.RowCount(UnitTesting.ReturnsTableWithFiveRows())
-        ),
-        Fact("Values should be equal (using a let statement)",
-            "Hello World",
-            let
-                a = "Hello World"
-            in
-                a
-        )
+    facts = {
+        Fact(
+        // name of the test
+        "Check that this function returns 'ABC'",
+        // expected value
+        "ABC",
+        // expression to evaluate (let or single statement)
+        UnitTesting.ReturnsABC()),
+        Fact("Check that this function returns '123'", "124", UnitTesting.Returns123()),
+        Fact("Result should contain 5 rows", 5, Table.RowCount(UnitTesting.ReturnsTableWithFiveRows())),
+        Fact("Values should be equal (using a let statement)", "Hello World", let a = "Hello World" in a)
     },
-
     report = Facts.Summarize(facts)
 ][report];
 
-/// COMMON UNIT TESTING CODE 
+/// COMMON UNIT TESTING CODE
 Fact = (_subject as text, _expected, _actual) as record =>
-[   expected = try _expected,
-    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
-    actual = try _actual,
-    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
-    attempt = try safeExpected = safeActual,
-    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
-    resultOp = if result = "Success ✓" then " = " else " <> ",
-    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
-    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
-    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
-    fact =
-    [   Result = result &" "& addendumEvalAttempt,
-        Notes =_subject,
-        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
-    ]
-][fact];
+    [
+        expected = try _expected,
+        safeExpected = if expected[HasError] then "Expected : " & @ValueToText(expected[Error]) else expected[Value],
+        actual = try _actual,
+        safeActual = if actual[HasError] then "Actual : " & @ValueToText(actual[Error]) else actual[Value],
+        attempt = try safeExpected = safeActual,
+        result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+        resultOp = if result = "Success ✓" then " = " else " <> ",
+        addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+        addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+        addendumEvalActual = try @ValueToText(safeActual) otherwise "...",
+        fact = [
+            Result = result & " " & addendumEvalAttempt,
+            Notes = _subject,
+            Details = " (" & addendumEvalExpected & resultOp & addendumEvalActual & ")"
+        ]
+    ][fact];
 
-Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject, _{0}, _{1}));
 
 Facts.Summarize = (_facts as list) as table =>
-[   Fact.CountSuccesses = (count, i) =>
-    [   result = try i[Result],
-        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
-    ][sum],
-    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
-    total = List.Count(_facts),
-    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
-    result = if passed = total then "Success" else "⛔",
-    rate = Number.IntegerDivide(100*passed, total),
-    header =
-    [   Result = result,
-        Notes = Text.Format(format, {passed, total-passed}),
-        Details = Text.Format("#{0}% success rate", {rate})
-    ],
-    report = Table.FromRecords(List.Combine({{header},_facts}))
-][report];
+    [
+        Fact.CountSuccesses = (count, i) =>
+            [
+                result = try i[Result],
+                sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+            ][sum],
+        passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+        total = List.Count(_facts),
+        format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+        result = if passed = total then "Success" else "⛔",
+        rate = Number.IntegerDivide(100 * passed, total),
+        header = [
+            Result = result,
+            Notes = Text.Format(format, {passed, total - passed}),
+            Details = Text.Format("#{0}% success rate", {rate})
+        ],
+        report = Table.FromRecords(List.Combine({{header}, _facts}))
+    ][report];
 
 ValueToText = (value, optional depth) =>
     let
-        List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
-
-        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
-
-        Serialize.Function =    (x) => _serialize_function_param_type(
-                                          Type.FunctionParameters(Value.Type(x)),
-                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
-                                       " as " &
-                                       _serialize_function_return_type(Value.Type(x)) &
-                                       " => (...) ",
-
-        Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
-
-        Serialize.Record =      (x) => "[ " &
-                                       List.TransformAndCombine(
-                                            Record.FieldNames(x), 
-                                            (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
-                                            ", ") &
-                                       " ] ",
-
-        Serialize.Table =       (x) => "#table( type " &
-                                        _serialize_table_type(Value.Type(x)) &
-                                        ", " &
-                                        Serialize(Table.ToRows(x)) &
-                                        ") ",
-                                    
-        Serialize.Identifier =  Expression.Identifier,
-
-        Serialize.Type =        (x) => "type " & _serialize_typename(x),
-                                    
-                             
-        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
-                                    let
-                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
-                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
-                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
-                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
-                                    in
-                                
-                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
-                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
-                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
-                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
-                                    
-                                        if x = type any then "any" else
-                                        let base = Type.NonNullable(x) in
-                                          (if Type.IsNullable(x) then "nullable " else "") &       
-                                          (if base = type anynonnull then "anynonnull" else                
-                                          if base = type binary then "binary" else                
-                                          if base = type date   then "date"   else
-                                          if base = type datetime then "datetime" else
-                                          if base = type datetimezone then "datetimezone" else
-                                          if base = type duration then "duration" else
-                                          if base = type logical then "logical" else
-                                          if base = type none then "none" else
-                                          if base = type null then "null" else
-                                          if base = type number then "number" else
-                                          if base = type text then "text" else 
-                                          if base = type time then "time" else 
-                                          if base = type type then "type" else 
-                                      
-                                          /* Abstract types: */
-                                          if base = type function then "function" else
-                                          if base = type table then "table" else
-                                          if base = type record then "record" else
-                                          if base = type list then "list" else
-                                      
-                                          "any /*Actually unknown type*/"),
-
-        _serialize_table_type =     (x) => 
-                                           let 
-                                             schema = Type.TableSchema(x)
-                                           in
-                                             "table " &
-                                             (if Table.IsEmpty(schema) then "" else 
-                                                 "[" & List.TransformAndCombine(
-                                                     Table.ToRecords(Table.Sort(schema,"Position")),
-                                                     each Serialize.Identifier(_[Name]) & " = " & _[Kind],
-                                                     ", ") &
-                                                 "] "),
-
-        _serialize_record_type =    (x) => 
-                                            let flds = Type.RecordFields(x)
-                                            in
-                                                if Record.FieldCount(flds)=0 then "record" else
-                                                    "[" & List.TransformAndCombine(
-                                                        Record.FieldNames(flds),
-                                                        (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
-                                                        ", ") & 
-                                                    (if Type.IsOpenRecord(x) then ", ..." else "") &
-                                                    "]",
-
-        _serialize_function_type =  (x) => _serialize_function_param_type(
-                                              Type.FunctionParameters(x),
-                                              Type.FunctionRequiredParameters(x) ) &
-                                            " as " &
-                                            _serialize_function_return_type(x),
-    
-        _serialize_function_param_type = (t,n) => 
-                                let
-                                    funsig = Table.ToRecords(
-                                        Table.TransformColumns(
-                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
-                                            { "isOptional", (x)=> x>n } ) )
-                                in
-                                    "(" & 
-                                    List.TransformAndCombine(
-                                        funsig,
-                                        (item)=>
-                                            (if item[isOptional] then "optional " else "") &
-                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
-                                        ", ") &
-                                     ")",
-
-        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
-
-        Serialize = (x) as text => 
-                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
-                           if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
-                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
-                           if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
-                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
-                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
-                           if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
-                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
-                           "[#_unable_to_serialize_#]"                     
+        List.TransformAndCombine = (list, transform, separator) =>
+            Text.Combine(List.Transform(list, transform), separator),
+        Serialize.Binary = (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+        Serialize.Function = (x) =>
+            _serialize_function_param_type(
+                Type.FunctionParameters(Value.Type(x)), Type.FunctionRequiredParameters(Value.Type(x))
+            )
+                & " as "
+                & _serialize_function_return_type(Value.Type(x))
+                & " => (...) ",
+        Serialize.List = (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+        Serialize.Record = (x) =>
+            "[ "
+                & List.TransformAndCombine(
+                    Record.FieldNames(x),
+                    (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                    ", "
+                )
+                & " ] ",
+        Serialize.Table = (x) =>
+            "#table( type " & _serialize_table_type(Value.Type(x)) & ", " & Serialize(Table.ToRows(x)) & ") ",
+        Serialize.Identifier = Expression.Identifier,
+        Serialize.Type = (x) => "type " & _serialize_typename(x),
+        _serialize_typename = (x, optional funtype as logical) =>
+            // Optional parameter: Is this being used as part of a function signature?
+            let
+                isFunctionType = (x as type) =>
+                    try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                isTableType = (x as type) => try if Type.TableSchema(x) is table then true else false otherwise false,
+                isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false
+            otherwise
+                false,
+                isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+            in
+                if funtype = null and isTableType(x) then
+                    _serialize_table_type(x)
+                else if funtype = null and isListType(x) then
+                    "{ " & @_serialize_typename(Type.ListItem(x)) & " }"
+                else if funtype = null and isFunctionType(x) then
+                    "function " & _serialize_function_type(x)
+                else if funtype = null and isRecordType(x) then
+                    _serialize_record_type(x)
+                else if x = type any then
+                    "any"
+                else
+                    let
+                        base = Type.NonNullable(x)
+                    in
+                        (if Type.IsNullable(x) then "nullable " else "")
+                            & (
+                                if base = type anynonnull then
+                                    "anynonnull"
+                                else if base = type binary then
+                                    "binary"
+                                else if base = type date then
+                                    "date"
+                                else if base = type datetime then
+                                    "datetime"
+                                else if base = type datetimezone then
+                                    "datetimezone"
+                                else if base = type duration then
+                                    "duration"
+                                else if base = type logical then
+                                    "logical"
+                                else if base = type none then
+                                    "none"
+                                else if base = type null then
+                                    "null"
+                                else if base = type number then
+                                    "number"
+                                else if base = type text then
+                                    "text"
+                                else if base = type time then
+                                    "time"
+                                else if base = type type then
+                                    "type"
+                                else
+                                // Abstract types
+                                if base = type function then
+                                    "function"
+                                else if base = type table then
+                                    "table"
+                                else if base = type record then
+                                    "record"
+                                else if base = type list then
+                                    "list"
+                                else
+                                    "any /*Actually unknown type*/"
+                            ),
+        _serialize_table_type = (x) =>
+            let
+                schema = Type.TableSchema(x)
+            in
+                "table "
+                    & (
+                        if Table.IsEmpty(schema) then
+                            ""
+                        else
+                            "["
+                                & List.TransformAndCombine(
+                                    Table.ToRecords(Table.Sort(schema, "Position")),
+                                    each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                    ", "
+                                )
+                                & "] "
+                    ),
+        _serialize_record_type = (x) =>
+            let
+                flds = Type.RecordFields(x)
+            in
+                if Record.FieldCount(flds) = 0 then
+                    "record"
+                else
+                    "["
+                        & List.TransformAndCombine(
+                            Record.FieldNames(flds),
+                            (item) =>
+                                Serialize.Identifier(item) & "=" & _serialize_typename(
+                                    Record.Field(flds, item)[Type]
+                                ),
+                            ", "
+                        )
+                        & (if Type.IsOpenRecord(x) then ", ..." else "")
+                        & "]",
+        _serialize_function_type = (x) =>
+            _serialize_function_param_type(Type.FunctionParameters(x), Type.FunctionRequiredParameters(x))
+                & " as "
+                & _serialize_function_return_type(x),
+        _serialize_function_param_type = (t, n) =>
+            let
+                funsig = Table.ToRecords(
+                    Table.TransformColumns(
+                        Table.AddIndexColumn(Record.ToTable(t), "isOptional", 1), {"isOptional", (x) => x > n}
+                    )
+                )
+            in
+                "("
+                    & List.TransformAndCombine(
+                        funsig,
+                        (item) =>
+                            (if item[isOptional] then "optional " else "")
+                                & Serialize.Identifier(item[Name])
+                                & " as "
+                                & _serialize_typename(item[Value], true),
+                        ", "
+                    )
+                    & ")",
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true),
+        Serialize = (x) as text =>
+            if x is binary then
+                try Serialize.Binary(x) otherwise "null /*serialize failed*/"
+            else if x is date then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetime then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is datetimezone then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is duration then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is function then
+                try Serialize.Function(x) otherwise "null /*serialize failed*/"
+            else if x is list then
+                try Serialize.List(x) otherwise "null /*serialize failed*/"
+            else if x is logical then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is null then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is number then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is record then
+                try Serialize.Record(x) otherwise "null /*serialize failed*/"
+            else if x is table then
+                try Serialize.Table(x) otherwise "null /*serialize failed*/"
+            else if x is text then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is time then
+                try Expression.Constant(x) otherwise "null /*serialize failed*/"
+            else if x is type then
+                try Serialize.Type(x) otherwise "null /*serialize failed*/"
+            else
+                "[#_unable_to_serialize_#]"
     in
         try Serialize(value) otherwise "<serialization failed>";


### PR DESCRIPTION
- Mostly ensures line comments have exactly 1 space between `//` and the content
    - A few places were left along because the whitespace was helping formatting
- Used the [powerquery-formatter](https://github.com/microsoft/powerquery-formatter) on several files