### PR TITLE
Update PQTest docs link in PQSDKTestSuites.md and RunPQSDKTestSuites.ps1

### DIFF
--- a/testframework/tests/PQSDKTestSuites.md
+++ b/testframework/tests/PQSDKTestSuites.md
@@ -1,6 +1,6 @@
 # PQ SDK Test Framework - Test Suites
 
-The PQ SDK Test Framework consists of prebuilt test suite to easily validate any extension connectors. The test framework is built to run tests in PQ/PQOut format using the `pqtest.exe compare` command. Please review the documentation in [PQTest docs](https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-overview) to learn more about running tests with PQTest.exe in PQ/PQOut format.
+The PQ SDK Test Framework consists of prebuilt test suite to easily validate any extension connectors. The test framework is built to run tests in PQ/PQOut format using the `pqtest.exe compare` command. Please review the documentation in [PQTest docs](https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview) to learn more about running tests with PQTest.exe in PQ/PQOut format.
 
 The test framework consists of the following:
 
@@ -85,7 +85,7 @@ The test data is provided in the form of csv along with the schema defintion. Th
 
   Take the output from the above command and replace the Username and Password values with correct credentials and save  it as json file (Ex: contoso_cred.json).
 
-- Then, use this `set-credential` command store credentials that will be used by the `compare` commands to run the tests. Using the existing powershell window, set the credentials for your extension using the json credential file generated in the previous step. Refer the [PQTest docs](https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-overview) to learn more about the usage of `credential-template` and `set-credential` to set up the credentials for your connector.
+- Then, use this `set-credential` command store credentials that will be used by the `compare` commands to run the tests. Using the existing powershell window, set the credentials for your extension using the json credential file generated in the previous step. Refer the [PQTest docs](https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview) to learn more about the usage of `credential-template` and `set-credential` to set up the credentials for your connector.
 
   ```
   Get-Content "<Replace with path to the json credential file>" | & $PQTestExe set-credential -e "$Extension" -q "<Replace with the path to any parameter query file>
@@ -162,7 +162,7 @@ Example:
 
 ```
 
-Please review the [PQTest docs](https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-overview) for more information on running tests with PQTest.exe.
+Please review the [PQTest docs](https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview) for more information on running tests with PQTest.exe.
 
 ## Running query folding tests
 
@@ -197,4 +197,4 @@ Below are sample instructions on how custom tests can be added:
 - Create a settings file `CustomSettings.json` under `testframework\tests\ConnectorConfigs\<Connector Name>\Settings` folder. Add the paths for test folder `"QueryFilePath": "TestSuites/Custom"` and the parameter query file `"ParameterQueryFilePath": "ParameterQueries/<Connector Name>/<Connector Name>.parameterquery.pq"` in it.
 - Run the test first time to generate the PQOut output file. 
 - Subsequent runs will validate the output generated with the PQOut output file. 
-- Please review the documentation in [PQTest docs](https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-overview) for more information on creating new tests using the compare command.
+- Please review the documentation in [PQTest docs](https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview) for more information on creating new tests using the compare command.

--- a/testframework/tests/RunPQSDKTestSuites.ps1
+++ b/testframework/tests/RunPQSDKTestSuites.ps1
@@ -9,8 +9,8 @@
        Pre-Requisite: Ensure the credentials are setup for your connector following the instructions here: https://learn.microsoft.com/en-us/power-query/power-query-sdk-vs-code#set-credential
 
        .LINK
-       General pqtest.md: https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-overview
-       Compare command specific pqtest.md : https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-commands-and-options
+       General pqtest.md: https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview
+       Compare command specific pqtest.md : https://learn.microsoft.com/power-query/sdk-tools/pqtest-commands-options
        
        .PARAMETER PQTestExePath
        Provide the path to PQTest.exe. Ex: 'C:\\Users\\ContosoUser\\.vscode\\extensions\\powerquery.vscode-powerquery-sdk-0.2.3-win32-x64\\.nuget\\Microsoft.PowerQuery.SdkTools.2.114.4\\tools\\PQTest.exe'

--- a/testframework/tests/RunPQSDKTestSuites.ps1
+++ b/testframework/tests/RunPQSDKTestSuites.ps1
@@ -6,7 +6,7 @@
        .DESCRIPTION
        This script will execute the PQ SDK PQ/PQOut tests present under Sanity, Standard & DataSourceSpecific folders. 
        RunPQSDKTestSuitesSettings.json file is used provide configurations need to this script. Please review the template RunPQSDKTestSuitesSettingsTemplate.json for more info.
-       Pre-Requisite: Ensure the credentials are setup for your connector following the instructions here: https://learn.microsoft.com/en-us/power-query/power-query-sdk-vs-code#set-credential
+       Pre-Requisite: Ensure the credentials are setup for your connector following the instructions here: https://learn.microsoft.com/power-query/power-query-sdk-vs-code#set-credential
 
        .LINK
        General pqtest.md: https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview


### PR DESCRIPTION
## Issue
PQ Test docs link were broken

## Solution

- PQ Test docs link changed from https://learn.microsoft.com/power-query/powerquery-sdktools/pqtest-overview to https://learn.microsoft.com/power-query/sdk-tools/pqtest-overview in PQSDKTestSuites.md
- Fixed other PQ Test docs links in RunPQSDKTestSuites.ps1
- Removed locale form learn page link in RunPQSDKTestSuites.ps1