### PR TITLE
Fix string literal escapes

### DIFF
--- a/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Finish/SqlODBC.pq
@@ -105,7 +105,7 @@ Config_UseParameterBindings = null;  // true, false, null
 //
 // Set to null to determine the value from the driver. 
 //
-Config_StringLiterateEscapeCharacters  = { "\" }; // ex. { "\" }
+Config_StringLiteralEscapeCharacters  = { "'" }; // ex. { "'" } or { {"\", "\\"}, {"'", "\'"} }
 
 // Override this if the driver expects the use of CAST instead of CONVERT.
 // By default, the query will be generated using ANSI SQL CONVERT syntax.
@@ -356,10 +356,10 @@ BuildOdbcConfig = () as record =>
                 defaultConfig,
                 
         withEscape = 
-            if (Config_StringLiterateEscapeCharacters <> null) then 
+            if (Config_StringLiteralEscapeCharacters <> null) then 
                 let
                     caps = [
-                        StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                        StringLiteralEscapeCharacters = Config_StringLiteralEscapeCharacters
                     ]
                 in
                     Merge(withParams, caps)

--- a/samples/NativeQuery/ODBC/SQL ODBC/Start/SqlODBC.pq
+++ b/samples/NativeQuery/ODBC/SQL ODBC/Start/SqlODBC.pq
@@ -105,7 +105,7 @@ Config_UseParameterBindings = null;  // true, false, null
 //
 // Set to null to determine the value from the driver. 
 //
-Config_StringLiterateEscapeCharacters  = { "\" }; // ex. { "\" }
+Config_StringLiteralEscapeCharacters  = { "'" }; // ex. { "'" } or { {"\", "\\"}, {"'", "\'"} }
 
 // Override this if the driver expects the use of CAST instead of CONVERT.
 // By default, the query will be generated using ANSI SQL CONVERT syntax.
@@ -335,10 +335,10 @@ BuildOdbcConfig = () as record =>
                 defaultConfig,
                 
         withEscape = 
-            if (Config_StringLiterateEscapeCharacters <> null) then 
+            if (Config_StringLiteralEscapeCharacters <> null) then 
                 let
                     caps = [
-                        StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                        StringLiteralEscapeCharacters = Config_StringLiteralEscapeCharacters
                     ]
                 in
                     Merge(withParams, caps)

--- a/samples/ODBC/HiveSample/HiveSample.pq
+++ b/samples/ODBC/HiveSample/HiveSample.pq
@@ -18,8 +18,8 @@ Config_SqlConformance = SQL_SC[SQL_SC_SQL92_FULL];
 Config_DefaultUsernamePasswordHandling = true;
 // true, false, null
 Config_UseParameterBindings = false;
-// ex. { "\" }
-Config_StringLiterateEscapeCharacters = {"\"};
+// ex. { "'" } or { {"\", "\\"}, {"'", "\'"} }
+Config_StringLiteralEscapeCharacters = { {"\", "\\"}, {"'", "\'"} };
 // true, false, null
 Config_UseCastInsteadOfConvert = null;
 // true, false
@@ -270,12 +270,12 @@ BuildOdbcConfig = () as record =>
             else
                 defaultConfig,
         withEscape =
-            if (Config_StringLiterateEscapeCharacters <> null) then
+            if (Config_StringLiteralEscapeCharacters <> null) then
                 let
                     caps = withParams[SqlCapabilities]
                         & [
                             SqlCapabilities = [
-                                StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                                StringLiteralEscapeCharacters = Config_StringLiteralEscapeCharacters
                             ]
                         ]
                 in

--- a/samples/ODBC/RedshiftODBC/RedshiftODBC.pq
+++ b/samples/ODBC/RedshiftODBC/RedshiftODBC.pq
@@ -13,8 +13,8 @@ Config_SqlConformance = ODBC[SQL_SC][SQL_SC_SQL92_FULL];
 Config_DefaultUsernamePasswordHandling = true;
 // true, false, null
 Config_UseParameterBindings = true;
-// ex. { "\" }
-Config_StringLiterateEscapeCharacters = {"\"};
+// ex. { "'" } or { {"\", "\\"}, {"'", "\'"} }
+Config_StringLiteralEscapeCharacters  = { "'" };
 // true, false, null
 Config_UseCastInsteadOfConvert = true;
 // true, false
@@ -255,12 +255,12 @@ BuildOdbcConfig = () as record =>
             else
                 defaultConfig,
         withEscape =
-            if (Config_StringLiterateEscapeCharacters <> null) then
+            if (Config_StringLiteralEscapeCharacters <> null) then
                 let
                     caps = withParams[SqlCapabilities]
                         & [
                             SqlCapabilities = [
-                                StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                                StringLiteralEscapeCharacters = Config_StringLiteralEscapeCharacters
                             ]
                         ]
                 in

--- a/samples/ODBC/SqlODBC/SqlODBC.pq
+++ b/samples/ODBC/SqlODBC/SqlODBC.pq
@@ -103,8 +103,8 @@ Config_UseParameterBindings = null;
 //
 // Set to null to determine the value from the driver.
 //
-Config_StringLiterateEscapeCharacters = {"\"};
-// ex. { "\" }
+Config_StringLiteralEscapeCharacters  = { "'" }; // ex. { "'" } or { {"\", "\\"}, {"'", "\'"} }
+
 // Override this if the driver expects the use of CAST instead of CONVERT.
 // By default, the query will be generated using ANSI SQL CONVERT syntax.
 //
@@ -364,10 +364,10 @@ BuildOdbcConfig = () as record =>
             else
                 defaultConfig,
         withEscape =
-            if (Config_StringLiterateEscapeCharacters <> null) then
+            if (Config_StringLiteralEscapeCharacters <> null) then
                 let
                     caps = [
-                        StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                        StringLiteralEscapeCharacters = Config_StringLiteralEscapeCharacters
                     ]
                 in
                     Merge(withParams, caps)


### PR DESCRIPTION
Fix a typo in a symbol name. Correct examples of string literal escape replacement to match what I think they should be for SQL Server, Redshift and Hive SQL, respectively.