### PR TITLE
Make FoldListFirst.query.pq deterministic

### DIFF
--- a/testframework/tests/TestSuites/Standard/Functions/FoldListFirst.query.pq
+++ b/testframework/tests/TestSuites/Standard/Functions/FoldListFirst.query.pq
@@ -1,6 +1,7 @@
 (parameter) => 
 let
-	SelectColumns = Table.Group(parameter[taxi_table], {"PULocationID"}, {{"First", each List.First([trip_distance]), type number}}),
+    Sorted = Table.Sort(parameter[taxi_table], {{"PULocationID", Order.Ascending}, {"RecordID", Order.Ascending}}),
+    SelectColumns = Table.Group(Sorted, {"PULocationID"}, {{"First", each List.First([trip_distance]), type number}}, GroupKind.Local),
     Sort = Table.Sort(SelectColumns,{"PULocationID", Order.Descending}),
     FirstN = Table.FirstN(Sort, 1)
 in


### PR DESCRIPTION
- Updates `FoldListFirst.query.pq` so it sorts rows by `PULocationID` and `RecordID` before calling `List.First`.
- The test previously used `List.First` after grouping without a stable row order. Some backends can return a different first row when the query is folded, which makes the test inconsistent.